### PR TITLE
fixed implementation, added tests for properties

### DIFF
--- a/src/lp_norm_oracles.jl
+++ b/src/lp_norm_oracles.jl
@@ -79,7 +79,7 @@ end
 
 LMO for the K-norm ball, intersection of L_1-ball (τK) and L_∞-ball (τ/K)
 ```
-C = B_1(τK) ∩ B_∞(τ)
+C_{K,τ} = conv { B_1(τ) ∪ B_∞(τ / K) }
 ```
 with `τ` the `right_hand_side` parameter.
 """
@@ -94,6 +94,8 @@ function compute_extreme_point(lmo::KNormBallLMO{T}, direction) where {T}
         1,
     )
     v1 = compute_extreme_point(LpNormLMO{T, 1}(lmo.right_hand_side) , direction)
-    v∞ = compute_extreme_point(LpNormLMO{T, Inf}(K * lmo.right_hand_side) , direction)
-    return min.(v1, v∞)
+    vinf = compute_extreme_point(LpNormLMO{T, Inf}(lmo.right_hand_side / K) , direction)
+    o1 = dot(v1, direction)
+    oinf = dot(vinf, direction)
+    return o1 ≤ oinf ? v1 : vinf
 end

--- a/test/lmo.jl
+++ b/test/lmo.jl
@@ -87,10 +87,20 @@ end
                 c = 5 * randn(n)
                 v = FrankWolfe.compute_extreme_point(lmo_ball, c)
                 v1 = FrankWolfe.compute_extreme_point(FrankWolfe.LpNormLMO{1}(τ), c)
-                v_inf = FrankWolfe.compute_extreme_point(FrankWolfe.LpNormLMO{Inf}(τ * K), c)
-                for idx in eachindex(v)
-                    @test v[idx] ≈ min(v1[idx], v_inf[idx])
+                v_inf = FrankWolfe.compute_extreme_point(FrankWolfe.LpNormLMO{Inf}(τ / K), c)
+                # K-norm is convex hull of union of the two norm epigraphs
+                # => cannot do better than the best of them
+                @test dot(v, c) ≈ min(
+                    dot(v1, c),
+                    dot(v_inf, c),
+                )
+                # test according to original norm definition
+                # norm constraint must be tight
+                K_sum = 0.0
+                for vi in sort!(abs.(v), rev=true)[1:K]
+                    K_sum += vi
                 end
+                @test K_sum ≈ τ
             end
         end
     end


### PR DESCRIPTION
Fixes https://github.com/ZIB-IOL/FrankWolfe.jl/issues/28
I added tests on two properties:
- The K-norm ball LMO yields the best objective between the corresponding L1 and L_inf
- the K largest abs values are equal to tau (original norm definition)