### PR TITLE
Momentum

### DIFF
--- a/src/FrankWolfe.jl
+++ b/src/FrankWolfe.jl
@@ -132,20 +132,21 @@ function fw(f, grad, lmo, x0; stepSize::LSMethod = agnostic, L = Inf, gamma0 = 0
     if emph === memory && !isa(x, Array)
         x = convert(Vector{promote_type(eltype(x), Float64)}, x)
     end
-    niter = 0
-
+    first_iter = true
+    gradient = 0
     while t <= maxIt && dualGap >= max(epsilon,eps())
         primal = f(x)
-        gradient = grad(x)
-
-        # m = if isnothing(momentum) || niter == 0
-        #     gradient
-        # else
-        #     # reaching this branch after first iteration, so m defined
-        #     @. m = momentum * m + (1 - momentum) * gradient
-        # end
-
-        # v = compute_extreme_point(lmo, m)
+        
+        if isnothing(momentum) || first_iter
+            gradient = grad(x)
+        else
+            if emph === memory
+                @. gradient = (momentum * gradient) .+ (1 - momentum) .* grad(x)
+            else
+                gradient = (momentum * gradient) .+ (1 - momentum) * grad(x)
+            end
+        end
+        first_iter = false
 
         v = compute_extreme_point(lmo, gradient)
         
@@ -287,7 +288,7 @@ function lcg(f, grad, lmoBase, x0; stepSize::LSMethod = agnostic, L = Inf,
         elseif stepSize === nonconvex
             gamma = 1 / sqrt(t+1)
         elseif stepSize === shortstep
-            gamma = dualGap // (L * dot(x-v,x-v) )
+            gamma = dualGap / (L * dot(x-v,x-v) )
         end
 
         @emphasis(emph, x = (1 - gamma) * x + gamma * v)

--- a/src/simplex_oracles.jl
+++ b/src/simplex_oracles.jl
@@ -13,6 +13,8 @@ end
 
 UnitSimplexOracle{T}() where {T} = UnitSimplexOracle{T}(one(T))
 
+UnitSimplexOracle(rhs::Integer) = UnitSimplexOracle{Rational{BigInt}}(rhs)
+
 """
 LMO for scaled unit simplex.
 Returns either vector of zeros or vector with one active value equal to RHS if
@@ -55,6 +57,8 @@ struct ProbabilitySimplexOracle{T} <: LinearMinimizationOracle
 end
 
 ProbabilitySimplexOracle{T}() where {T} = ProbabilitySimplexOracle{T}(one(T))
+
+ProbabilitySimplexOracle(rhs::Integer) = ProbabilitySimplexOracle{Float64}(rhs)
 
 """
 LMO for scaled probability simplex.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,7 +14,7 @@ include("lmo.jl")
 end
 
 @testset "FrankWolfe.jl" begin
-    @testset "Testing vanilla Frank-Wolfe with various step size strategies" begin
+    @testset "Testing vanilla Frank-Wolfe with various step size and momentum strategies" begin
         f(x) = LinearAlgebra.norm(x)^2
         grad(x) = 2x
         lmo_prob = FrankWolfe.ProbabilitySimplexOracle(1)
@@ -25,8 +25,9 @@ end
         @test abs(FrankWolfe.fw(f,grad,lmo_prob,x0,maxIt=1000,stepSize=FrankWolfe.nonconvex,verbose=true)[3] - 0.2) < 1.0e-2
         @test FrankWolfe.fw(f,grad,lmo_prob,x0,maxIt=1000,stepSize=FrankWolfe.shortstep,L=2,verbose=true)[3] ≈ 0.2 
         @test abs(FrankWolfe.fw(f,grad,lmo_prob,x0,maxIt=1000,stepSize=FrankWolfe.nonconvex,verbose=true)[3] - 0.2) < 1.0e-2
-        # x0 = 1.0 * FrankWolfe.compute_extreme_point(lmo_prob, zeros(5))
-        # @test abs(FrankWolfe.fw(f,grad,lmo_prob,x0,maxIt=1000,stepSize=FrankWolfe.agnostic,verbose=false, momentum = 0.9)[3] - 0.2) < 1.0e-3
+        @test abs(FrankWolfe.fw(f,grad,lmo_prob,x0,maxIt=1000,stepSize=FrankWolfe.agnostic,verbose=false, momentum = 0.9)[3] - 0.2) < 1.0e-3
+        @test abs(FrankWolfe.fw(f,grad,lmo_prob,x0,maxIt=1000,stepSize=FrankWolfe.agnostic,verbose=false, momentum = 0.5)[3] - 0.2) < 1.0e-3
+        @test abs(FrankWolfe.fw(f,grad,lmo_prob,x0,maxIt=1000,stepSize=FrankWolfe.agnostic,verbose=false, momentum=0.9, emph=FrankWolfe.memory)[3] - 0.2) < 1.0e-3
     end
     @testset "Testing Lazified Conditional Gradients with various step size strategies" begin
         f(x) = LinearAlgebra.norm(x)^2


### PR DESCRIPTION
Optional momentum added to vanilla FW.
I ran some experiments on the quadratic loss function and probability simplex, the take away is:

Momentum is worse than vanilla FW steps when out of place, mostly because it allocates twice. This is underlined here by the fact that the prob simplex has a very memory-efficient structure, so needing to allocate anything else dominates memory usage.

It seems to be a tie between momentum and no momentum in the in-place version

```julia
julia> begin
               f(x) = LinearAlgebra.norm(x)^2
               grad(x) = 2x
               const lmo_prob = FrankWolfe.ProbabilitySimplexOracle(1)
               const x0 = FrankWolfe.compute_extreme_point(lmo_prob, zeros(500))
               @info "no momentum"
               display(@benchmark( FrankWolfe.fw(f,grad,lmo_prob,x0,maxIt=1000,stepSize=FrankWolfe.agnostic,verbose=false)))
               @info "momentum 0.9"
               display(@benchmark( FrankWolfe.fw(f,grad,lmo_prob,x0,maxIt=1000,stepSize=FrankWolfe.agnostic,verbose=false, momentum = 0.9)))
               @info "momentum 0.5"
               display(@benchmark(FrankWolfe.fw(f,grad,lmo_prob,x0,maxIt=1000,stepSize=FrankWolfe.agnostic,verbose=false, momentum = 0.5)))
               @info "momentum in-place"
               display(@benchmark(FrankWolfe.fw(f,grad,lmo_prob,x0,maxIt=1000,stepSize=FrankWolfe.agnostic,verbose=false, momentum = 0.9, emph=FrankWolfe.memory)))
               @info "no momentum in-place"
               display(@benchmark(FrankWolfe.fw(f,grad,lmo_prob,x0,maxIt=1000,stepSize=FrankWolfe.agnostic,verbose=false, momentum = 0.9, emph=FrankWolfe.memory)))
       end
[ Info: no momentum
BenchmarkTools.Trial: 
  memory estimate:  12.12 MiB
  allocs estimate:  13019
  --------------
  minimum time:     3.826 ms (0.00% GC)
  median time:      4.257 ms (0.00% GC)
  mean time:        4.804 ms (10.00% GC)
  maximum time:     9.156 ms (37.16% GC)
  --------------
  samples:          1040
  evals/sample:     1
[ Info: momentum 0.9
BenchmarkTools.Trial: 
  memory estimate:  24.11 MiB
  allocs estimate:  20019
  --------------
  minimum time:     6.634 ms (0.00% GC)
  median time:      8.561 ms (18.72% GC)
  mean time:        8.481 ms (11.38% GC)
  maximum time:     15.148 ms (20.93% GC)
  --------------
  samples:          590
  evals/sample:     1
[ Info: momentum 0.5
BenchmarkTools.Trial: 
  memory estimate:  24.11 MiB
  allocs estimate:  20019
  --------------
  minimum time:     7.749 ms (0.00% GC)
  median time:      9.745 ms (17.47% GC)
  mean time:        9.728 ms (10.50% GC)
  maximum time:     15.594 ms (14.29% GC)
  --------------
  samples:          514
  evals/sample:     1
[ Info: momentum in-place
BenchmarkTools.Trial: 
  memory estimate:  903.63 KiB
  allocs estimate:  27023
  --------------
  minimum time:     7.825 ms (0.00% GC)
  median time:      8.295 ms (0.00% GC)
  mean time:        8.781 ms (0.82% GC)
  maximum time:     16.238 ms (0.00% GC)
  --------------
  samples:          570
  evals/sample:     1
[ Info: no momentum in-place
BenchmarkTools.Trial: 
  memory estimate:  903.63 KiB
  allocs estimate:  27023
  --------------
  minimum time:     7.863 ms (0.00% GC)
  median time:      8.408 ms (0.00% GC)
  mean time:        8.972 ms (0.84% GC)
  maximum time:     16.215 ms (0.00% GC)
  --------------
  samples:          558
  evals/sample:     1
```