### PR TITLE
Bug in shortstep rule in BCG and in vanilla FW

### DIFF
--- a/src/FrankWolfe.jl
+++ b/src/FrankWolfe.jl
@@ -173,7 +173,7 @@ function fw(
         elseif line_search === nonconvex
             gamma = 1 / sqrt(t + 1)
         elseif line_search === shortstep
-            gamma = dual_gap / (L * norm(x - v)^2)
+            gamma = dot(gradient, x - v) / (L * norm(x - v)^2)
         elseif line_search === rationalshortstep
             ratDualGap = sum((x - v) .* gradient)
             gamma = ratDualGap // (L * sum((x - v) .^ 2))
@@ -373,7 +373,7 @@ function lcg(
         elseif line_search == nonconvex
             gamma = 1 / sqrt(t + 1)
         elseif line_search == shortstep
-            gamma = dual_gap / (L * dot(x - v, x - v))
+            gamma = dot(gradient, x - v) / (L * dot(x - v, x - v))
         end
 
         @emphasis(emphasis, x = (1 - gamma) * x + gamma * v)

--- a/src/blended_cg.jl
+++ b/src/blended_cg.jl
@@ -170,7 +170,7 @@ function bcg(
                 elseif line_search == nonconvex
                     gamma = 1 / sqrt(t + 1)
                 elseif line_search == shortstep
-                    gamma = dual_gap / (L * dot(x - v, x - v))
+                    gamma =  dot(gradient, x - v) / (L * dot(x - v, x - v))
                 elseif line_search == adaptive
                     L, gamma = adaptive_step_size(f, gradient, x, x - v, L)
                 end


### PR DESCRIPTION
Changed how the shorstep is computed in both of these algorithms. The inner product between gradient and direction of movement should be used in the numerator, not the FW gap (as we don't always move towards the FW vertex, because that vertex may be expensive to compute, and sometimes we use cached vertices etc...)