### PR TITLE
Fix bug in mimax computation for BCG. Prevent dual gap from being computed twice with shortstep.

### DIFF
--- a/src/FrankWolfe.jl
+++ b/src/FrankWolfe.jl
@@ -173,7 +173,7 @@ function fw(
         elseif line_search === nonconvex
             gamma = 1 / sqrt(t + 1)
         elseif line_search === shortstep
-            gamma = dot(gradient, x - v) / (L * norm(x - v)^2)
+            gamma = dual_gap / (L * norm(x - v)^2)
         elseif line_search === rationalshortstep
             ratDualGap = sum((x - v) .* gradient)
             gamma = ratDualGap // (L * sum((x - v) .^ 2))

--- a/src/active_set.jl
+++ b/src/active_set.jl
@@ -196,8 +196,8 @@ indicating if the direction improvement is above a threshold.
 """
 function find_minmax_directions(active_set::ActiveSet, direction, Φ; goodstep_tolerance=0.75)
     idx_fw = idx_as = -1
-    v_fw = Inf
-    v_as = -Inf
+    v_fw = dot(direction, active_set.atoms[1])
+    v_as = v_fw
     for (idx, a) in enumerate(active_set.atoms)
         val = dot(direction, a)
         if val ≤ v_fw

--- a/src/fw_algorithms.jl
+++ b/src/fw_algorithms.jl
@@ -140,7 +140,6 @@ function stochastic_frank_wolfe(
         elseif line_search == nonconvex
             gamma = 1 / sqrt(t + 1)
         elseif line_search == shortstep
-            dual_gap = dot(x, gradient) - dot(v, gradient)
             gamma = dual_gap / (L * norm(x - v)^2)
         elseif line_search == rationalshortstep
             rat_dual_gap = sum((x - v) .* gradient)


### PR DESCRIPTION
The bug in the minmax computation has to do with the if-else structure, and the case where the away-vertex is the first in the active set. With the old bug if the away vertex is the first in the active set, it will enter the first if statement for the "fw" direction as v_fw is initialized as  v_fw  = Inf, and not enter the "else" condition, and thus we will never select this vertex as an away vertex, and it will hinder progress. The images show the FW gap convergence for BCG before (1st image) and after the bug fix (2nd image), as well as reference performance from the Python code (3rd image). (for testing purposes I'm computing the FW gap at every iteration).

![Julia_with_bug](https://user-images.githubusercontent.com/56440520/108523167-9b8ae300-729b-11eb-93de-c714e9f4feb5.png)
![Julia_without_bug](https://user-images.githubusercontent.com/56440520/108523165-9af24c80-729b-11eb-90b2-01ee1ab16031.png)
![Python_implementation](https://user-images.githubusercontent.com/56440520/108523164-9af24c80-729b-11eb-98ed-694902242e6b.png)





The other changes in the fw algorithm prevents an extra dual gap computation for the shorstep, as it is always updated at every iteration if a shorstep is selected.