### PR TITLE
Improvement to the stability of the simplex descent.

### DIFF
--- a/src/active_set.jl
+++ b/src/active_set.jl
@@ -1,19 +1,21 @@
 
 """
-    ActiveSet{AT, R}
+    ActiveSet{AT, R, IT}
 
 Represents an active set of extreme vertices collected in a FW algorithm,
 along with their coefficients `(λ_i, a_i)`.
 `R` is the type of the `λ_i`, `AT` is the type of the atoms `a_i`.
+The iterate `x = ∑λ_i a_i` is stored in x with type `IT`.
 """
-struct ActiveSet{AT,R} <: AbstractVector{Tuple{R,AT}}
+struct ActiveSet{AT,R,IT} <: AbstractVector{Tuple{R,AT}}
     weights::Vector{R}
     atoms::Vector{AT}
+    x::IT
 end
 
-ActiveSet{AT,R}() where {AT,R} = ActiveSet{AT,R}([], [])
+ActiveSet{AT,R}() where {AT,R} = ActiveSet{AT,R,Vector{float(eltype(AT))}}([], [])
 
-ActiveSet{AT}() where {AT} = ActiveSet{AT,Float64}()
+ActiveSet{AT}() where {AT} = ActiveSet{AT,Float64,Vector{float(eltype(AT))}}()
 
 function ActiveSet(tuple_values::AbstractVector{Tuple{R,AT}}) where {AT,R}
     n = length(tuple_values)
@@ -23,18 +25,24 @@ function ActiveSet(tuple_values::AbstractVector{Tuple{R,AT}}) where {AT,R}
         weights[idx] = tuple_values[idx][1]
         atoms[idx] = tuple_values[idx][2]
     end
-    return ActiveSet{AT,R}(weights, atoms)
+    x = float.(similar(atoms[1]))
+    as = ActiveSet{AT,R,typeof(x)}(weights, atoms, x)
+    update_active_set_iterate!(as)
+    return as
 end
 
 function ActiveSet{AT,R}(tuple_values::AbstractVector{<:Tuple{<:Number,<:Any}}) where {AT,R}
     n = length(tuple_values)
     weights = Vector{R}(undef, n)
     atoms = Vector{AT}(undef, n)
+    x = float.(similar(tuple_values[1][2]))
+    x .= 0
     @inbounds for idx in 1:n
         weights[idx] = tuple_values[idx][1]
         atoms[idx] = tuple_values[idx][2]
+        x .+= weights[idx] * atoms[idx]
     end
-    return ActiveSet{AT,R}(weights, atoms)
+    return ActiveSet{AT,R, typeof(x)}(weights, atoms, x)
 end
 
 Base.getindex(as::ActiveSet, i) = (as.weights[i], as.atoms[i])
@@ -45,6 +53,8 @@ function Base.push!(as::ActiveSet, (λ, a))
     push!(as.atoms, a)
     return as
 end
+
+# these two functions do not update the active set iterate,
 
 function Base.deleteat!(as::ActiveSet, idx)
     deleteat!(as.weights, idx)
@@ -61,6 +71,7 @@ end
 function Base.empty!(as::ActiveSet)
     empty!(as.atoms)
     empty!(as.weights)
+    as.x .= 0
     return as
 end
 
@@ -70,19 +81,43 @@ end
 Adds the atom to the active set with weight lambda or adds lambda to existing atom.
 """
 function active_set_update!(active_set::ActiveSet, lambda, atom, renorm=true)
-    active_set_renormalize!(active_set)
+    x_before = active_set.x * (1-lambda) + lambda * atom
+    xa_before = sum(λi * ai for (λi, ai) in active_set) * (1 - lambda) + lambda * atom
+    @debug "diff v beginning $(norm(x_before - xa_before))"
+    if norm(x_before - xa_before) > 1e-6
+        error("")
+    end
     # rescale active set
     active_set.weights .*= (1 - lambda)
     # add value for new atom
     idx = find_atom(active_set, atom)
+    updating = false
     if idx > 0
         @inbounds active_set.weights[idx] = active_set.weights[idx] + lambda
+        updating = true
     else
         push!(active_set, (lambda, atom))
     end
+    # active_set.x .= 0
+    # for (λ, a) in active_set
+    #     active_set.x .= active_set.x + λ * a
+    # end
+    @. active_set.x = active_set.x * (1 - lambda) + lambda * atom
     if renorm
-        active_set_cleanup!(active_set)
+        active_set_cleanup!(active_set, update=false)
         active_set_renormalize!(active_set)
+    end
+    xreal = sum(λi * ai for (λi, ai) in active_set)
+    # works
+    # update_active_set_iterate!(active_set)
+    # not
+    nafter = norm(active_set.x)
+    @debug "diff $(norm(xreal - active_set.x))"
+    @debug "update? $updating"
+    @debug "diff2 $(norm(xreal - x_before))"
+    @debug "diff3 $(norm(xreal - xa_before))"
+    if (norm(xreal - active_set.x)) > 0.01
+        error("QUIT")
     end
     return active_set
 end
@@ -110,22 +145,23 @@ end
     compute_active_set_iterate(active_set)
 """
 function compute_active_set_iterate(active_set)
-    return sum(λi * ai for (λi, ai) in active_set)
+    return active_set.x
 end
 
-# NO NOT use for now - mysterious BigFloat + Sparse problems
-function compute_active_set_iterate!(x, active_set)
-    x .= 0
-    SparseArrays.dropzeros!(x)
-    y = compute_active_set_iterate(active_set)
-    n0y = norm(y)
-    y2 = compute_active_set_iterate(active_set)
-    x .= deepcopy(y)
-    return x
+function update_active_set_iterate!(active_set)
+    active_set.x .= 0
+    for (λi, ai) in active_set
+        active_set.x .+= λi * ai
+    end
+    return active_set.x
 end
 
-function active_set_cleanup!(active_set; weight_purge_threshold=1e-12)
-    return filter!(e -> e[1] > weight_purge_threshold, active_set)
+function active_set_cleanup!(active_set; weight_purge_threshold=1e-12, update=true)
+    filter!(e -> e[1] > weight_purge_threshold, active_set)
+    if update
+        update_active_set_iterate!(active_set)
+    end
+    return nothing
 end
 
 function find_atom(active_set::ActiveSet, atom)
@@ -215,5 +251,6 @@ end
 function active_set_initialize!(as::ActiveSet{AT, R}, v) where {AT, R}
     empty!(as)
     push!(as, (one(R), v))
+    @. as.x = one(R) * v
     return as
 end

--- a/src/blended_cg.jl
+++ b/src/blended_cg.jl
@@ -1,15 +1,3 @@
-stop(text="Stop.") = throw(StopException(text))
-
-struct StopException{T}
-    S::T
-end
-
-function Base.showerror(io::IO, ex::StopException, bt; backtrace=true)
-    Base.with_output_color(get(io, :color, false) ? :green : :nothing, io) do io
-        showerror(io, ex.S)
-    end
-end
-
 
 function bcg(
     f,
@@ -24,12 +12,12 @@ function bcg(
     trajectory=false,
     verbose=false,
     linesearch_tol=1e-7,
-    emphasis::Emphasis=blas,
+    emphasis=nothing,
     Ktolerance=1.0,
     goodstep_tolerance=1.0,
     weight_purge_threshold=1e-9,
     gradient=nothing,
-    WT=Float64,
+    direction_storage=nothing,
     lmo_kwargs...,
 )
     function print_header(data)
@@ -77,7 +65,7 @@ function bcg(
     t = 0
     primal = Inf
     dual_gap = Inf
-    active_set = ActiveSet([(one(WT), x0)])
+    active_set = ActiveSet([(1.0, x0)])
     x = x0
     if gradient === nothing
         gradient = similar(x)
@@ -90,6 +78,10 @@ function bcg(
     tt = regular
     time_start = time_ns()
     v = x0
+    if direction_storage === nothing
+        direction_storage = Vector{float(eltype(x))}()
+        Base.sizehint!(direction_storage, 100)
+    end
 
     if line_search == shortstep && !isfinite(L)
         @error("Lipschitz constant not set to a finite value. Prepare to blow up spectacularly.")
@@ -103,12 +95,10 @@ function bcg(
         println("\nBlended Conditional Gradients Algorithm.")
         numType = eltype(x0)
         println(
-            "EMPHASIS: $emphasis STEPSIZE: $line_search EPSILON: $epsilon max_iteration: $max_iteration TYPE: $numType",
+            "EMPHASIS: $memory STEPSIZE: $line_search EPSILON: $epsilon max_iteration: $max_iteration TYPE: $numType",
         )
         println("K: $Ktolerance")
-        if emphasis == memory
-            println("WARNING: In memory emphasis mode iterates are written back into x0!")
-        end
+        println("WARNING: In memory emphasis mode iterates are written back into x0!")
         headers = (
             "Type",
             "Iteration",
@@ -123,8 +113,8 @@ function bcg(
         print_header(headers)
     end
 
-    if emphasis == memory && !isa(x, Union{Array, SparseVector})
-        x = convert(Vector{promote_type(eltype(x), Float64)}, x)
+    if !isa(x, Union{Array, SparseVector})
+        x = convert(Vector{float(eltype(x))}, x)
     end
     non_simplex_iter = 0
     nforced_fw = 0
@@ -143,11 +133,11 @@ function bcg(
             tt = simplex_descent
             force_fw_step = update_simplex_gradient_descent!(
                 active_set,
-                x,
                 gradient,
                 f,
                 L=L,
                 weight_purge_threshold=weight_purge_threshold,
+                storage=direction_storage,
             )
             nforced_fw += force_fw_step
         else
@@ -187,13 +177,9 @@ function bcg(
                 end
                 gamma = min(1.0, gamma)
                 if gamma == 1.0
-                    active_set = ActiveSet([(1.0, v)])
-                    @. x = v
-                    #x = v
+                    active_set_initialize!(active_set, v)
                 else
                     active_set_update!(active_set, gamma, v)
-                    @. x += gamma*(v - x)
-                    #x += gamma*(v - x)
                 end
             end
         end
@@ -235,7 +221,6 @@ function bcg(
         v = compute_extreme_point(lmo, gradient)
         primal = f(x)
         dual_gap = dot(x, gradient) - dot(v, gradient)
-        #dual_gap = 2phi
         rep = (
             last,
             string(t - 1),
@@ -291,15 +276,37 @@ https://arxiv.org/abs/1805.07311
 """
 function update_simplex_gradient_descent!(
     active_set::ActiveSet,
-    x,
     direction,
     f;
     L=nothing,
     linesearch_tol=10e-10,
     step_lim=100,
     weight_purge_threshold=1e-12,
+    storage=nothing,
 )
-    c = [dot(direction, a) for a in active_set.atoms]
+    c = if storage === nothing
+        [dot(direction, a) for a in active_set.atoms]
+    else
+        if length(storage) == length(active_set)
+            for (idx, a) in enumerate(active_set.atoms)
+                storage[idx] = dot(direction, a)
+            end
+            storage
+        elseif length(storage) > length(active_set)
+            for (idx, a) in enumerate(active_set.atoms)
+                storage[idx] = dot(direction, a)
+            end
+            storage[1:length(active_set)]
+        else
+            for idx in 1:length(storage)
+                storage[idx] = dot(direction, active_set.atoms[idx])
+            end
+            for idx in (length(storage)+1):length(active_set)
+                push!(storage, dot(direction, active_set.atoms[idx]))
+            end
+            storage
+        end
+    end
     k = length(active_set)
     csum = sum(c)
     c .-= (csum / k)
@@ -339,12 +346,12 @@ function update_simplex_gradient_descent!(
 
 
     # TODO at some point avoid materializing both x and y
+    x = copy(active_set.x)
     η = max(0, η)
     @. active_set.weights -= η * d
-    y = compute_active_set_iterate(active_set)
+    y = copy(update_active_set_iterate!(active_set))
     if f(x) ≥ f(y)
         active_set_cleanup!(active_set, weight_purge_threshold=weight_purge_threshold)
-        @. x = y
         return false
     end
     linesearch_method = L === nothing || !isfinite(L) ? backtracking : shortstep
@@ -357,12 +364,11 @@ function update_simplex_gradient_descent!(
     gamma = min(1.0, gamma)
     # step back from y to x by (1 - γ) η d
     # new point is x - γ η d
-    @. active_set.weights += η * (1 - gamma) * d
     if gamma == 1.0
         active_set_cleanup!(active_set, weight_purge_threshold=weight_purge_threshold)
-        @. x = y
     else
-        @. x += gamma*(y - x)
+        @. active_set.weights += η * (1 - gamma) * d
+        @. active_set.x =  x + gamma * (y - x)
     end
     return false
 end

--- a/test/active_set.jl
+++ b/test/active_set.jl
@@ -95,7 +95,7 @@ end
     f(x) = (x[1] - 1)^2 + (x[2] - 1)^2
     ∇f(x) = [2 * (x[1] - 1), 2 * (x[2] - 1)]
     gradient_dir = ∇f([0, 0.5])
-    FrankWolfe.update_simplex_gradient_descent!(active_set, x, gradient_dir, f)
+    FrankWolfe.update_simplex_gradient_descent!(active_set, gradient_dir, f)
     @test length(active_set) == 2
     @test [1, 0] ∈ active_set.atoms
     @test [0, 1] ∈ active_set.atoms
@@ -104,7 +104,7 @@ end
     x2 = FrankWolfe.compute_active_set_iterate(active_set2)
     @test x2 ≈ [0.5, 0]
     gradient_dir = ∇f(FrankWolfe.compute_active_set_iterate(active_set2))
-    FrankWolfe.update_simplex_gradient_descent!(active_set2, x2, gradient_dir, f, L=4.0)
+    FrankWolfe.update_simplex_gradient_descent!(active_set2, gradient_dir, f, L=4.0)
     @test length(active_set) == 2
     @test [1, 0] ∈ active_set.atoms
     @test [0, 1] ∈ active_set.atoms
@@ -113,7 +113,7 @@ end
     for as in (active_set, active_set2)
         x = FrankWolfe.compute_active_set_iterate(as)
         gradient_dir = ∇f(x)
-        FrankWolfe.update_simplex_gradient_descent!(as, x, gradient_dir, f)
+        FrankWolfe.update_simplex_gradient_descent!(as, gradient_dir, f)
         @test length(active_set) == 1
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -588,13 +588,12 @@ end
         x0;
         line_search=FrankWolfe.backtracking,
         L=Inf,
-        epsilon=1e-7,
-        max_iteration=100000,
-        print_iter=100,
+        epsilon=1e-9,
+        max_iteration=k,
+        print_iter=1,
         trajectory=false,
         verbose=false,
         linesearch_tol=1e-10,
-        emphasis=FrankWolfe.blas,
     )
 
     @test x !== nothing


### PR DESCRIPTION
The simplex descent updates were causing some stability problems. 

If we denote the initial barycentric coordinates by \lambda, and we have some update \lambda - \eta*d there are instances where several indexes have their value set to zero (or to approximately zero), but we are only setting one of them to zero, in this case rem_idx. This means that the remaining indexes are set to a value that is close to zero, but is not zero. This causes errors that accumulate over time and can lead to worse stability of the simplex descent algorithm. Images include FW gap convergence before the fix (first image), after the fix (second image) and the Python reference run performance (third image):

![BCG_Julia_before](https://user-images.githubusercontent.com/56440520/108572589-a61b9b80-72e0-11eb-809c-44cde4508ae8.png)
![BCG_Julia_after](https://user-images.githubusercontent.com/56440520/108572592-a74cc880-72e0-11eb-91dc-4e6fadc10d7f.png)
![Python_implementation_longer_run](https://user-images.githubusercontent.com/56440520/108572595-a87df580-72e0-11eb-8ef0-4fc8a81df8a8.png)


Other changes include a clipping of the stepsize in the case where it is greater than one, a two-line way to find the maximum stepsize that we can take in the convex hull of the active set, and a fix to the indexes in find_minmax_directions.