### PR TITLE
allow more flexible mutable arrays

### DIFF
--- a/src/afw.jl
+++ b/src/afw.jl
@@ -31,7 +31,7 @@ function away_frank_wolfe(
     renorm_interval=1000,
     callback=nothing,
     timeout=Inf,
-    print_callback=FrankWolfe.print_callback,
+    print_callback=print_callback,
 )
 
     # format string for output of the algorithm

--- a/src/fw_algorithms.jl
+++ b/src/fw_algorithms.jl
@@ -30,7 +30,7 @@ function frank_wolfe(
     gradient=nothing,
     callback=nothing,
     timeout=Inf,
-    print_callback=FrankWolfe.print_callback,
+    print_callback=print_callback,
 )
 
     # format string for output of the algorithm
@@ -255,7 +255,7 @@ function lazified_conditional_gradient(
     VType=typeof(x0),
     callback=nothing,
     timeout=Inf,
-    print_callback=FrankWolfe.print_callback,
+    print_callback=print_callback,
 )
 
     # format string for output of the algorithm
@@ -305,7 +305,7 @@ function lazified_conditional_gradient(
     end
 
     if emphasis == memory && !isa(x, Union{Array,SparseArrays.AbstractSparseArray})
-        x = convert(Array{float(eltype(x))}, x)
+        x = copyto!(similar(x, float(eltype(x))), x)
     end
 
     if gradient === nothing
@@ -315,7 +315,7 @@ function lazified_conditional_gradient(
     # container for direction
     d = similar(x)
 
-    while t <= max_iteration && dual_gap >= max(epsilon, eps())
+    while t <= max_iteration && dual_gap >= max(epsilon, eps(float(eltype(x))))
 
         #####################
         # managing time and Ctrl-C
@@ -464,7 +464,7 @@ function stochastic_frank_wolfe(
     full_evaluation=false,
     callback=nothing,
     timeout=Inf,
-    print_callback=FrankWolfe.print_callback,
+    print_callback=print_callback,
 )
 
     # format string for output of the algorithm
@@ -507,8 +507,8 @@ function stochastic_frank_wolfe(
         print_callback(headers, format_string, print_header=true)
     end
 
-    if emphasis == memory && !isa(x, Array)
-        x = convert(Array{promote_type(eltype(x), Float64)}, x)
+    if emphasis == memory && !isa(x, Union{Array, SparseArrays.AbstractSparseArray})
+        x = copyto!(similar(x, float(eltype(x))), x)
     end
     first_iter = true
     gradient = 0

--- a/src/norm_oracles.jl
+++ b/src/norm_oracles.jl
@@ -148,7 +148,7 @@ Warning: this does not work (yet) with all number types, BigFloat and Float16 fa
 function compute_extreme_point(lmo::NuclearNormLMO, direction::AbstractMatrix; tol=1e-8, kwargs...)
     Z = Arpack.svds(direction, nsv=1, tol=tol)[1]
     u = -lmo.radius * view(Z.U, :)
-    return FrankWolfe.RankOneMatrix(u, Z.V[:])
+    return RankOneMatrix(u, Z.V[:])
 end
 
 function convert_mathopt(

--- a/src/types.jl
+++ b/src/types.jl
@@ -58,7 +58,7 @@ end
 
 Base.:+(y::AbstractVector, x::ScaledHotVector) = x + y
 
-function Base.:+(x::FrankWolfe.ScaledHotVector{T1}, y::FrankWolfe.ScaledHotVector{T2}) where {T1,T2}
+function Base.:+(x::ScaledHotVector{T1}, y::ScaledHotVector{T2}) where {T1,T2}
     n = length(x)
     T = promote_type(T1, T2)
     if n != length(y)


### PR DESCRIPTION
This solves a problem when the iterate is of a mutable type, which was previously not correctly captured