### PR TITLE
rank-one matrix unary operator

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -170,6 +170,8 @@ Base.@propagate_inbounds function Base.:-(a::RankOneMatrix, b::RankOneMatrix)
     return r
 end
 
+Base.:-(x::RankOneMatrix) = RankOneMatrix(-x.u, -x.v)
+
 Base.@propagate_inbounds function Base.:+(a::RankOneMatrix, b::RankOneMatrix)
     @boundscheck size(a) == size(b) || throw(DimensionMismatch())
     r = similar(a)

--- a/src/types.jl
+++ b/src/types.jl
@@ -170,7 +170,7 @@ Base.@propagate_inbounds function Base.:-(a::RankOneMatrix, b::RankOneMatrix)
     return r
 end
 
-Base.:-(x::RankOneMatrix) = RankOneMatrix(-x.u, -x.v)
+Base.:-(x::RankOneMatrix) = RankOneMatrix(-x.u, x.v)
 
 Base.@propagate_inbounds function Base.:+(a::RankOneMatrix, b::RankOneMatrix)
     @boundscheck size(a) == size(b) || throw(DimensionMismatch())

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -42,7 +42,7 @@ end
                 @test M + R ≈ R + R
                 @test M - R ≈ R - R
                 MR = -R
-                @test MR isa RankOneMatrix
+                @test MR isa FrankWolfe.RankOneMatrix
                 @test -MR == R
             end
         end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -41,6 +41,9 @@ end
             @testset "Add and sub" begin
                 @test M + R ≈ R + R
                 @test M - R ≈ R - R
+                MR = -R
+                @test MR isa RankOneMatrix
+                @test -MR == R
             end
         end
     end


### PR DESCRIPTION
`-(::RankOneMatrix)` was left undefined, which did cast it to a dense matrix by default