### PR TITLE
batch and momentum iterators

### DIFF
--- a/src/fw_algorithms.jl
+++ b/src/fw_algorithms.jl
@@ -450,7 +450,11 @@ implemented through the [FrankWolfe.StochasticObjective](@ref) interface.
 
 Keyword arguments include `batch_size` to pass a fixed `batch_size`
 or a `batch_iterator` implementing
-`batch_size = _batchsize_iterate(batch_iterator)`.
+`batch_size = FrankWolfe._batchsize_iterate(batch_iterator)` for algorithms like
+Variance-reduced and projection-free stochastic optimization, E Hazan, H Luo, 2016.
+
+Similarly, a constant `momentum` can be passed or replaced by a `momentum_iterator`
+implementing `momentum = FrankWolfe._momentum_iterate(momentum_iterator)`.
 """
 function stochastic_frank_wolfe(
     f::StochasticObjective,

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -895,3 +895,88 @@ function print_callback(data, format_string; print_header=false, print_footer=fa
         print_formatted(format_string, data...)
     end
 end
+
+"""
+    ExpMomentumIterator{T}
+
+Iterator for the momentum used in the variant of Stochastic Frank-Wolfe.
+Momentum coefficients are the values of the iterator:
+`ρ_t = num / (offset + t)^exp`
+
+The state corresponds to the iteration count.
+
+Source:
+Stochastic Conditional Gradient Methods: From Convex Minimization to Submodular Maximization
+Aryan Mokhtari, Hamed Hassani, Amin Karbasi, JMLR 2020.
+"""
+mutable struct ExpMomentumIterator{T}
+    exp::T
+    num::T
+    offset::T
+    iter::Int
+end
+
+ExpMomentumIterator() = ExpMomentumIterator(2/3, 4.0, 8.0, 0)
+
+function _momentum_iterate(em::ExpMomentumIterator)
+    em.iter += 1
+    return em.num / (em.offset + em.iter)^(em.exp)
+end
+
+"""
+    ConstantMomentumIterator{T}
+
+Iterator for momentum with a fixed damping value, always return the value and a dummy state.
+"""
+struct ConstantMomentumIterator{T}
+    v::T
+end
+
+_momentum_iterate(em::ConstantMomentumIterator) = em.v
+
+# batch sizes
+
+"""
+    ConstantBatchIterator(batch_size)
+
+Batch iterator always returning a constant batch size.
+"""
+struct ConstantBatchIterator
+    batch_size::Int
+end
+
+_batchsize_iterate(cbi::ConstantBatchIterator) = cbi.batch_size
+
+"""
+    IncrementBatchIterator(starting_batch_size, max_batch_size, [increment = 1])
+
+Batch size starting at starting_batch_size and incrementing by `increment` at every iteration.
+"""
+mutable struct IncrementBatchIterator
+    starting_batch_size::Int
+    max_batch_size::Int
+    increment::Int
+    iter::Int
+    maxreached::Bool
+end
+
+function IncrementBatchIterator(starting_batch_size::Int, max_batch_size::Int, increment::Int)
+    return IncrementBatchIterator(starting_batch_size, max_batch_size, increment, 0, false)
+end
+
+function IncrementBatchIterator(starting_batch_size::Int, max_batch_size::Int)
+    return IncrementBatchIterator(starting_batch_size, max_batch_size, 1, 0, false)
+end
+
+function _batchsize_iterate(ibi::IncrementBatchIterator)
+    if ibi.maxreached
+        return ibi.max_batch_size
+    end
+    new_size = ibi.starting_batch_size + ibi.iter * ibi.increment
+    ibi.iter += 1
+    if new_size > ibi.max_batch_size
+        ibi.maxreached = true
+        return ibi.max_batch_size
+    end
+    return new_size
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -577,13 +577,45 @@ end
         lmo,
         params,
         momentum=0.95,
-        verbose=false,
+        verbose=true,
         line_search=FrankWolfe.Nonconvex(),
         max_iteration=50_000,
         batch_size=length(f_stoch.xs) ÷ 100,
         trajectory=false,
     )
     @test norm(θ - params_perfect) ≤ 0.025 * length(θ)
+
+    # SFW with incrementing batch size
+    batch_iterator = FrankWolfe.IncrementBatchIterator(
+        length(f_stoch.xs) ÷ 1000,
+        length(f_stoch.xs) ÷ 10,
+        2,
+    )
+    θ, _, _, _, _ = FrankWolfe.stochastic_frank_wolfe(
+        f_stoch,
+        lmo,
+        params,
+        momentum=0.95,
+        verbose=false,
+        line_search=FrankWolfe.Nonconvex(),
+        max_iteration=5000,
+        batch_iterator=batch_iterator,
+        trajectory=false,
+    )
+    @test batch_iterator.maxreached
+    # SFW damped momentum 
+    momentum_iterator = FrankWolfe.ExpMomentumIterator()
+    θ, _, _, _, _ = FrankWolfe.stochastic_frank_wolfe(
+        f_stoch,
+        lmo,
+        params,
+        verbose=true,
+        line_search=FrankWolfe.Nonconvex(),
+        max_iteration=5000,
+        batch_size=1,
+        trajectory=false,
+        momentum_iterator=momentum_iterator,
+    )
 end
 
 @testset "Away-step FW" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -616,6 +616,17 @@ end
         trajectory=false,
         momentum_iterator=momentum_iterator,
     )
+    θ, _, _, _, _ = FrankWolfe.stochastic_frank_wolfe(
+        f_stoch,
+        lmo,
+        params,
+        verbose=true,
+        line_search=FrankWolfe.Nonconvex(),
+        max_iteration=5000,
+        batch_size=1,
+        trajectory=false,
+        momentum_iterator=nothing,
+    )
 end
 
 @testset "Away-step FW" begin


### PR DESCRIPTION
Adds a momentum and a batch iterator mechanism (both for SFW for now).

This allows both quantities to depend on the iteration count, implementing the schemes in both Hazan Luo 2016 and Mokhtari et al 2020