### PR TITLE
fix iterator sense

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -909,7 +909,7 @@ function momentum_iterate end
 
 Iterator for the momentum used in the variant of Stochastic Frank-Wolfe.
 Momentum coefficients are the values of the iterator:
-`ρ_t = num / (offset + t)^exp`
+`ρ_t = 1 - num / (offset + t)^exp`
 
 The state corresponds to the iteration count.
 
@@ -928,7 +928,7 @@ ExpMomentumIterator() = ExpMomentumIterator(2/3, 4.0, 8.0, 0)
 
 function momentum_iterate(em::ExpMomentumIterator)
     em.iter += 1
-    return em.num / (em.offset + em.iter)^(em.exp)
+    return 1 - em.num / (em.offset + em.iter)^(em.exp)
 end
 
 """

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -84,3 +84,9 @@ end
         0.9,
     )
 end
+
+@testset "Momentum tests" begin
+    it = FrankWolfe.ExpMomentumIterator()
+    it.num = 0
+    @test momentum_iterate(it) == 0
+end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -88,5 +88,6 @@ end
 @testset "Momentum tests" begin
     it = FrankWolfe.ExpMomentumIterator()
     it.num = 0
-    @test momentum_iterate(it) == 0
+    # no momentum -> 1
+    @test FrankWolfe.momentum_iterate(it) == 1
 end


### PR DESCRIPTION
The momentum yielded by the iterator must be inverted compared to the reference paper for the exponential decay