### PR TITLE
faster Rank-One dot

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -160,6 +160,7 @@ function LinearAlgebra.dot(
 end
 
 LinearAlgebra.dot(R::RankOneMatrix, M::Matrix) = dot(R.u, M, R.v)
+LinearAlgebra.dot(R::RankOneMatrix, M::Matrix) = dot(R.v, M, R.u)
 
 Base.@propagate_inbounds function Base.:-(a::RankOneMatrix, b::RankOneMatrix)
     @boundscheck size(a) == size(b) || throw(DimensionMismatch())

--- a/src/types.jl
+++ b/src/types.jl
@@ -159,6 +159,8 @@ function LinearAlgebra.dot(
     return s
 end
 
+LinearAlgebra.dot(R::RankOneMatrix, M::Matrix) = dot(R.u, M, R.v)
+
 Base.@propagate_inbounds function Base.:-(a::RankOneMatrix, b::RankOneMatrix)
     @boundscheck size(a) == size(b) || throw(DimensionMismatch())
     r = similar(a)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -52,6 +52,10 @@ end
                 @test -MR == R
                 @test 3R isa FrankWolfe.RankOneMatrix
             end
+            @testset "Dot" begin
+                @test dot(R, M) ≈ dot(collect(R), M)
+                @test dot(R, sparse(M)) ≈ dot(collect(R), M)
+            end
         end
     end
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,6 +1,7 @@
 import FrankWolfe
 using LinearAlgebra
 using Test
+using SparseArrays
 
 @testset "Simple benchmark_oracles function" begin
     n = Int(1e3)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -54,6 +54,7 @@ end
             end
             @testset "Dot" begin
                 @test dot(R, M) ≈ dot(collect(R), M)
+                @test dot(M, R) ≈ dot(M, collect(R))
                 @test dot(R, sparse(M)) ≈ dot(collect(R), M)
             end
         end


### PR DESCRIPTION
Before:
```julia
julia> @btime dot($R, $M)
  13.250 μs (0 allocations: 0 bytes)
166.28728225939486
```
after
```julia
julia> @btime dot($R, $M)
  1.629 μs (0 allocations: 0 bytes)
166.28728225939446
```