### PR TITLE
Minor change of iteration counter placement

### DIFF
--- a/src/afw.jl
+++ b/src/afw.jl
@@ -234,10 +234,10 @@ function away_frank_wolfe(
             primal = f(x)
             dual_gap = phi_value
         end
-
+        t += 1
         if callback !== nothing
             state = (
-                t=t,
+                t=t - 1,
                 primal=primal,
                 dual=primal - dual_gap,
                 dual_gap=phi_value,
@@ -253,7 +253,6 @@ function away_frank_wolfe(
                 break
             end
         end
-        t += 1
     end
 
     # recompute everything once more for final verfication / do not record to trajectory though for now!

--- a/src/blended_cg.jl
+++ b/src/blended_cg.jl
@@ -202,9 +202,11 @@ function blended_conditional_gradient(
 
         x = get_active_set_iterate(active_set)
         dual_gap = phi
+        t = t + 1
+        non_simplex_iter += 1
         if callback !== nothing
             state = (
-                t=t,
+                t=t - 1,
                 primal=primal,
                 dual=primal - dual_gap,
                 dual_gap=dual_gap,
@@ -212,7 +214,7 @@ function blended_conditional_gradient(
                 x=x,
                 v=v,
                 active_set=active_set,
-                non_simplex_iter=non_simplex_iter,
+                non_simplex_iter=non_simplex_iter - 1,
                 gradient=gradient,
                 tt=tt,
             )
@@ -220,8 +222,6 @@ function blended_conditional_gradient(
                 break
             end
         end
-        t = t + 1
-        non_simplex_iter += 1
     end
 
     ## post-processing and cleanup after loop

--- a/src/fw_algorithms.jl
+++ b/src/fw_algorithms.jl
@@ -170,9 +170,10 @@ function frank_wolfe(
             linesearch_workspace,
             memory_mode
         )
+        t = t + 1
         if callback !== nothing
             state = (
-                t=t,
+                t=t - 1,
                 primal=primal,
                 dual=primal - dual_gap,
                 dual_gap=dual_gap,
@@ -192,8 +193,6 @@ function frank_wolfe(
         end
 
         x = muladd_memory_mode(memory_mode, x, gamma, d)
-
-        t = t + 1
     end
     # recompute everything once for final verfication / do not record to trajectory though for now!
     # this is important as some variants do not recompute f(x) and the dual_gap regularly but only when reporting
@@ -400,9 +399,10 @@ function lazified_conditional_gradient(
             memory_mode
         )
 
+        t += 1
         if callback !== nothing
             state = (
-                t=t,
+                t=t - 1,
                 primal=primal,
                 dual=primal - dual_gap,
                 dual_gap=dual_gap,
@@ -424,7 +424,6 @@ function lazified_conditional_gradient(
         end
 
         x = muladd_memory_mode(memory_mode, x, gamma, d)
-        t += 1
     end
 
     # recompute everything once for final verfication / do not record to trajectory though for now!
@@ -649,9 +648,10 @@ function stochastic_frank_wolfe(
         # note: only linesearch methods that do not require full evaluations are supported
         # so nothing is passed as function 
         gamma = perform_line_search(line_search, t, nothing, nothing, gradient, x, x - v, 1.0, linesearch_workspace, memory_mode)
+        t += 1
         if callback !== nothing
             state = (
-                t=t,
+                t=t - 1,
                 primal=primal,
                 dual=primal - dual_gap,
                 dual_gap=dual_gap,
@@ -670,8 +670,6 @@ function stochastic_frank_wolfe(
 
         d = muladd_memory_mode(memory_mode, d, x, v)
         x = muladd_memory_mode(memory_mode, x, gamma, d)
-
-        t += 1
     end
     # recompute everything once for final verfication / no additional callback call
     # this is important as some variants do not recompute f(x) and the dual_gap regularly but only when reporting

--- a/src/pairwise.jl
+++ b/src/pairwise.jl
@@ -253,9 +253,10 @@ function blended_pairwise_conditional_gradient(
         )
             primal = f(x)
         end
+        t += 1
         if callback !== nothing
             state = (
-                t=t,
+                t=t - 1,
                 primal=primal,
                 dual=primal - phi,
                 dual_gap=phi,
@@ -271,7 +272,6 @@ function blended_pairwise_conditional_gradient(
                 break
             end
         end
-        t += 1
     end
 
     # recompute everything once more for final verfication / do not record to trajectory though for now!


### PR DESCRIPTION
Switched the position of the iteration counter being increased (t=+1) and the call to the callback.

We can stop the solving process from the callback if we wish. In that case, though, iteration counter was not increased causing confusing logs.