### PR TITLE
weak separation oracle

### DIFF
--- a/docs/src/reference/2_lmo.md
+++ b/docs/src/reference/2_lmo.md
@@ -5,7 +5,7 @@ The Linear Minimization Oracle (LMO) is a key component called at each iteration
 v\in \argmin_{x\in \mathcal{C}} \langle d,x \rangle.
 ```
 
-See [Combettes, Pokutta 2021](https://arxiv.org/abs/2101.10040) for references on most LMOs
+See [Combettes, Pokutta 2021](https://arxiv.org/abs/2101.10040) for references on essential LMOs
 implemented in the package and their comparison with projection operators.
 
 ## Interface and wrappers
@@ -18,6 +18,13 @@ All of them are subtypes of [`FrankWolfe.LinearMinimizationOracle`](@ref) and im
 ```@docs
 compute_extreme_point
 ```
+
+Optionally, an LMO can implement a weak separation procedure based either on a heuristic or on an approximation algorithm:
+```@docs
+compute_weak_separation_point
+```
+
+Weak separation procedures will be used in the methods using an active set and lazified variants only.
 
 We also provide some meta-LMOs wrapping another one with extended behavior:
 ```@docs

--- a/src/abstract_oracles.jl
+++ b/src/abstract_oracles.jl
@@ -87,7 +87,7 @@ function compute_weak_separation_point(lmo::SingleLastCachedLMO, direction, max_
         lmo.last_vertex = v
     end
     T = promote_type(eltype(v), eltype(direction))
-    return (v, zero(T))
+    return v, zero(T)
 end
 
 function compute_extreme_point(
@@ -294,7 +294,7 @@ function compute_weak_separation_point(lmo::VectorCacheLMO, direction, max_value
         push!(lmo.vertices, v)
     end
     T = promote_type(eltype(v), eltype(direction))
-    return v, zero(v)
+    return v, zero(T)
 end
 
 function compute_extreme_point(

--- a/src/afw.jl
+++ b/src/afw.jl
@@ -470,7 +470,7 @@ function afw_step(x, gradient, lmo, active_set, epsilon, d; memory_mode::MemoryE
     else
         (compute_extreme_point(lmo, gradient), 0.0)
     end
-    dual_gap = grad_dot_x - fast_dot(v, gradient) - gap
+    dual_gap = grad_dot_x - fast_dot(v, gradient)
     if dual_gap > away_gap && dual_gap >= epsilon
         tt = gap == 0.0 ? regular : weaksep
         gamma_max = one(a_lambda)
@@ -488,7 +488,6 @@ function afw_step(x, gradient, lmo, active_set, epsilon, d; memory_mode::MemoryE
         fw_step_taken = false
         index = a_loc
     else
-        @assert gap == 0.0
         tt = away
         gamma_max = zero(a_lambda)
         vertex = a
@@ -496,7 +495,7 @@ function afw_step(x, gradient, lmo, active_set, epsilon, d; memory_mode::MemoryE
         fw_step_taken = false
         index = a_loc
     end
-    return d, vertex, index, gamma_max, dual_gap, away_step_taken, fw_step_taken, tt
+    return d, vertex, index, gamma_max, dual_gap + gap, away_step_taken, fw_step_taken, tt
 end
 
 function fw_step(x, gradient, lmo, d; memory_mode::MemoryEmphasis = InplaceEmphasis())

--- a/src/afw.jl
+++ b/src/afw.jl
@@ -440,8 +440,7 @@ function lazy_afw_step(x, gradient, lmo, active_set, phi, epsilon, d; use_extra_
                 away_step_taken = false
                 fw_step_taken = true
                 index = -1
-                #Lower our expectation for progress.
-            else
+            else # lower our expectation for progress.
                 tt = dualstep
                 phi = min(dual_gap, phi / 2.0)
                 gamma_max = zero(a_lambda)
@@ -471,7 +470,7 @@ function afw_step(x, gradient, lmo, active_set, epsilon, d; memory_mode::MemoryE
     else
         (compute_extreme_point(lmo, gradient), 0.0)
     end
-    dual_gap = grad_dot_x - fast_dot(v, gradient) + gap
+    dual_gap = grad_dot_x - fast_dot(v, gradient) - gap
     if dual_gap > away_gap && dual_gap >= epsilon
         tt = gap == 0.0 ? regular : weaksep
         gamma_max = one(a_lambda)
@@ -489,6 +488,7 @@ function afw_step(x, gradient, lmo, active_set, epsilon, d; memory_mode::MemoryE
         fw_step_taken = false
         index = a_loc
     else
+        @assert gap == 0.0
         tt = away
         gamma_max = zero(a_lambda)
         vertex = a

--- a/src/defs.jl
+++ b/src/defs.jl
@@ -19,6 +19,7 @@ struct OutplaceEmphasis <: MemoryEmphasis end
     away = 6
     pairwise = 7
     drop = 8
+    weaksep = 9
     simplex_descent = 101
     gap_step = 102
     last = 1000
@@ -34,6 +35,7 @@ const st = (
     away="A",
     pairwise="P",
     drop="D",
+    weaksep="W",
     simplex_descent="SD",
     gap_step="GS",
     last="Last",

--- a/src/moi_oracle.jl
+++ b/src/moi_oracle.jl
@@ -128,7 +128,6 @@ function _optimize_and_return(lmo, variables)
     term_st = MOI.get(lmo.o, MOI.TerminationStatus())
     if term_st ∉ (MOI.OPTIMAL, MOI.ALMOST_OPTIMAL, MOI.SLOW_PROGRESS)
         @error "Unexpected termination: $term_st"
-        return MOI.get.(lmo.o, MOI.VariablePrimal(), variables)
     end
     return MOI.get.(lmo.o, MOI.VariablePrimal(), variables)
 end

--- a/src/pairwise.jl
+++ b/src/pairwise.jl
@@ -291,10 +291,11 @@ function blended_pairwise_conditional_gradient(
                     else
                         (v, gap) = if weak_separation
                             lazy_threshold = fast_dot(gradient, x) - phi / lazy_tolerance
-                            (v, gap) = compute_weak_separation_point(lmo, gradient, lazy_threshold)
+                            compute_weak_separation_point(lmo, gradient, lazy_threshold)
                         else
                             v = compute_extreme_point(lmo, gradient)
                             gap = 0.0
+                            (v, gap)
                         end
                     end
                     tt = gap == 0.0 ? regular : weaksep
@@ -303,13 +304,13 @@ function blended_pairwise_conditional_gradient(
             vertex_taken = v
             dual_gap = fast_dot(gradient, x) - fast_dot(gradient, v)
             # if we are about to exit, compute dual_gap with the cleaned-up x
-            if dual_gap + gap ≤ epsilon
+            if dual_gap ≤ epsilon
                 active_set_renormalize!(active_set)
                 active_set_cleanup!(active_set)
                 compute_active_set_iterate!(active_set)
                 x = get_active_set_iterate(active_set)
                 grad!(gradient, x)
-                dual_gap = fast_dot(gradient, x) - fast_dot(gradient, v) + gap
+                dual_gap = fast_dot(gradient, x) - fast_dot(gradient, v)
             end
             # Note: In the following, we differentiate between lazy and non-lazy updates.
             # The reason is that the non-lazy version does not use phi but the lazy one heavily depends on it.
@@ -320,7 +321,7 @@ function blended_pairwise_conditional_gradient(
             # - for lazy: we also accept slightly weaker vertices, those satisfying phi / lazy_tolerance
             # this should simplify the criterion.
             # DO NOT CHANGE without good reason and talk to Sebastian first for the logic behind this.
-            if !lazy || dual_gap ≥ phi / lazy_tolerance                  
+            if !lazy || dual_gap ≥ phi / lazy_tolerance
                 d = muladd_memory_mode(memory_mode, d, x, v)
 
                 gamma = perform_line_search(

--- a/src/pairwise.jl
+++ b/src/pairwise.jl
@@ -30,6 +30,7 @@ function blended_pairwise_conditional_gradient(
     add_dropped_vertices=false,
     use_extra_vertex_storage=false,
     recompute_last_vertex=true,
+    weak_separation=false,
 )
     # add the first vertex to active set from initialization
     active_set = ActiveSet([(1.0, x0)])
@@ -58,6 +59,7 @@ function blended_pairwise_conditional_gradient(
         add_dropped_vertices=add_dropped_vertices,
         use_extra_vertex_storage=use_extra_vertex_storage,
         recompute_last_vertex=recompute_last_vertex,
+        weak_separation=weak_separation,
     )
 end
 
@@ -90,6 +92,7 @@ function blended_pairwise_conditional_gradient(
     add_dropped_vertices=false,
     use_extra_vertex_storage=false,
     recompute_last_vertex=true,
+    weak_separation=false,
 )
 
     # format string for output of the algorithm
@@ -137,7 +140,7 @@ function blended_pairwise_conditional_gradient(
             "MEMORY_MODE: $memory_mode STEPSIZE: $line_search EPSILON: $epsilon MAXITERATION: $max_iteration TYPE: $NumType",
         )
         grad_type = typeof(gradient)
-        println("GRADIENTTYPE: $grad_type LAZY: $lazy lazy_tolerance: $lazy_tolerance")
+        println("GRADIENTTYPE: $grad_type LAZY: $lazy lazy_tolerance: $lazy_tolerance WEAK_SEPARATION: $weak_separation")
         println("Linear Minimization Oracle: $(typeof(lmo))")
         if use_extra_vertex_storage && !lazy
             @info("vertex storage only used in lazy mode")

--- a/src/pairwise.jl
+++ b/src/pairwise.jl
@@ -207,9 +207,9 @@ function blended_pairwise_conditional_gradient(
                 dot_x = fast_dot(gradient, x)
                 (v, weak_gap) = if weak_separation
                     # we need a separation point v
-                    # ⟨∇f(x), x-v⟩ ≥ local_gap * lazy_threshold
-                    # ⟨∇f(x), v⟩ ≤ ⟨∇f(x), x⟩ - local_gap * lazy_threshold
-                    threshold = dot_x - local_gap * lazy_threshold
+                    # ⟨∇f(x), x-v⟩ ≥ local_gap * lazy_tolerance
+                    # ⟨∇f(x), v⟩ ≤ ⟨∇f(x), x⟩ - local_gap * lazy_tolerance
+                    threshold = dot_x - local_gap * lazy_tolerance
                     compute_weak_separation_point(lmo, gradient, threshold)
                 else
                     v = compute_extreme_point(lmo, gradient)

--- a/src/pairwise.jl
+++ b/src/pairwise.jl
@@ -376,7 +376,7 @@ function blended_pairwise_conditional_gradient(
             else # dual step
                 # set to computed dual_gap for consistency between the lazy and non-lazy run.
                 # that is ok as we scale with the K = 2.0 default anyways
-                # we only update the dual gap if the step was regular (not lazy from discarded set)
+                # we only update the dual gap if the step was regular or weaksep (not lazy from discarded set)
                 if tt != lazylazy
                     @assert dual_gap + gap < phi
                     phi = dual_gap + gap

--- a/src/tracking.jl
+++ b/src/tracking.jl
@@ -55,7 +55,12 @@ end
 
 function compute_extreme_point(lmo::TrackingLMO, x; kwargs...)
     lmo.counter += 1
-    return compute_extreme_point(lmo.lmo, x)
+    return compute_extreme_point(lmo.lmo, x; kwargs...)
+end
+
+function compute_weak_separation_point(lmo::TrackingLMO, direction, max_value)
+    lmo.counter += 1
+    return compute_weak_separation_point(lmo.lmo, direction, max_value)
 end
 
 is_tracking_lmo(lmo) = false

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -787,6 +787,7 @@ include("generic-arrays.jl")
 end
 
 module WeakSeparation
+using Test
 @testset "weak separation oracles" begin
     include("weak_separation.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -785,3 +785,9 @@ include("generic-arrays.jl")
         end
     end
 end
+
+module WeakSeparation
+@testset "weak separation oracles" begin
+    include("weak_separation.jl")
+end
+end

--- a/test/weak_separation.jl
+++ b/test/weak_separation.jl
@@ -73,8 +73,8 @@ end
 
 @testset "AFW and BPCG with weak separation" begin
     n = 1000
-    # reference point to get an optimum on a face
-    ref_point = [0.6 + mod(idx, 2) for idx in 1:n]
+    # reference point to get an optimum with many vertices
+    ref_point = [0.4 + idx / n * mod(idx, 2) for idx in 1:n]
     f(x) = 1/2 / n * sum((x[i] - ref_point[i])^2 for i in eachindex(x))
     function grad!(storage, x)
         storage .= x
@@ -87,13 +87,12 @@ end
         x, v, primal, dual_gap, trajectory_exact, active_set_exact = FrankWolfe.away_frank_wolfe(f, grad!, tracking_lmo, x0, verbose=false, weak_separation=false, lazy=lazy)
         tracking_weak = FrankWolfe.TrackingLMO(Hypercube())
         x, v, primal, dual_gap, trajectory_weak, active_set_weak = FrankWolfe.away_frank_wolfe(f, grad!, tracking_weak, x0, verbose=false, weak_separation=true, lazy=lazy)
-        @test tracking_lmo.counter <= tracking_weak.counter
+        @test tracking_lmo.counter < tracking_weak.counter
 
         tracking_lmo = FrankWolfe.TrackingLMO(Hypercube())
         x, v, primal, dual_gap, trajectory_exact, active_set_exact = FrankWolfe.blended_pairwise_conditional_gradient(f, grad!, tracking_lmo, x0, verbose=false, weak_separation=false, lazy=lazy)
         tracking_weak = FrankWolfe.TrackingLMO(Hypercube())
         x, v, primal, dual_gap, trajectory_weak, active_set_weak = FrankWolfe.blended_pairwise_conditional_gradient(f, grad!, tracking_weak, x0, verbose=false, weak_separation=true, lazy=lazy)
-        @test tracking_lmo.counter <= tracking_weak.counter
-
+        @test tracking_lmo.counter < tracking_weak.counter
     end
 end

--- a/test/weak_separation.jl
+++ b/test/weak_separation.jl
@@ -26,7 +26,7 @@ end
 
 # a very naive implementation of a weak separation oracle without a gap (a heuristic)
 # we stop iterating through the indices whenever we obtain sufficient progress
-function FrankWolfe.compute_weak_separation_point(::Hypercube, direction::AbstractArray{T}, max_value) where {T}
+function FrankWolfe.compute_weak_separation_point(lmo::Hypercube, direction::AbstractArray{T}, max_value) where {T}
     v = similar(direction, T)
     v .= 0
     res = zero(T)

--- a/test/weak_separation.jl
+++ b/test/weak_separation.jl
@@ -76,10 +76,11 @@ end
     end
     lmo = Hypercube()
     x0 = FrankWolfe.compute_extreme_point(lmo, -ones(n))
-    tracking_lmo = FrankWolfe.TrackingLMO(lmo)
     for lazy in (false, true)
-        x, v, primal, dual_gap, trajectory_exact, active_set_exact = FrankWolfe.away_frank_wolfe(f, grad!, tracking_lmo, x0, verbose=true, weak_separation=false, lazy=lazy)
+        tracking_lmo = FrankWolfe.TrackingLMO(lmo)
+        x, v, primal, dual_gap, trajectory_exact, active_set_exact = FrankWolfe.away_frank_wolfe(f, grad!, tracking_lmo, x0, verbose=false, weak_separation=false, lazy=lazy)
         tracking_weak = FrankWolfe.TrackingLMO(lmo)
-        x, v, primal, dual_gap, trajectory_weak, active_set_weak = FrankWolfe.away_frank_wolfe(f, grad!, tracking_weak, x0, verbose=true, weak_separation=true, lazy=lazy)
+        x, v, primal, dual_gap, trajectory_weak, active_set_weak = FrankWolfe.away_frank_wolfe(f, grad!, tracking_weak, x0, verbose=false, weak_separation=true, lazy=lazy)
+        @test tracking_lmo.counter <= tracking_weak.counter
     end
 end

--- a/test/weak_separation.jl
+++ b/test/weak_separation.jl
@@ -1,0 +1,85 @@
+using FrankWolfe
+using LinearAlgebra
+using Test
+
+"""
+A test LMO representing the feasible set [0,1]^n
+"""
+struct Hypercube <: FrankWolfe.LinearMinimizationOracle
+end
+
+function FrankWolfe.compute_extreme_point(::Hypercube, direction::AbstractArray{T}) where {T}
+    v = similar(direction, T)
+    v .= 0
+    for idx in eachindex(v)
+        if direction[idx] < 0
+            v[idx] = 1
+        end
+    end
+    return v
+end
+
+# a very naive implementation of a weak separation oracle without a gap (a heuristic)
+# we stop iterating through the indices whenever we obtain sufficient progress
+function FrankWolfe.compute_weak_separation_point(::Hypercube, direction::AbstractArray{T}, max_value) where {T}
+    v = similar(direction, T)
+    v .= 0
+    res = zero(T)
+    gap = zero(T)
+    for idx in eachindex(v)
+        if direction[idx] < 0
+            v[idx] = 1
+            res += direction[idx]
+        end
+        if res <= max_value && idx != lastindex(v)
+            gap = T(Inf)
+            break
+            @info "avoided $(length(v) - idx) iterations"
+        end
+    end
+    return v, gap
+end
+
+@testset "Basic behaviour" begin
+    lmo = Hypercube()
+    direction = rand(4,2)
+    v = FrankWolfe.compute_extreme_point(lmo, direction)
+    @test size(v) == size(direction)
+    @test norm(v) == 0
+    (w, _) = FrankWolfe.compute_weak_separation_point(lmo, direction, -1)
+    @test norm(w) == 0
+    direction .*= -1
+    direction[end] -= 1
+    v = FrankWolfe.compute_extreme_point(lmo, direction)
+    @test v == ones(size(direction))
+    (w, gap0) = FrankWolfe.compute_weak_separation_point(lmo, direction, -1)
+    @test dot(w, direction) <= -1
+    @test gap0 == Inf
+    (w, gap1) = FrankWolfe.compute_weak_separation_point(lmo, direction, -1.5)
+    @test dot(w, direction) <= -1.5
+    @test gap1 == Inf
+    # asking for too much progress results in exact LMO call
+    (w, gap3) = FrankWolfe.compute_weak_separation_point(lmo, direction, -1000)
+    @test gap3 == 0.0
+    @test w == v
+end
+
+@testset "AFW with weak separation" begin
+    n = 1000
+    # reference point to get an optimum on a face
+    ref_point = [0.6 + mod(idx, 2) for idx in 1:n]
+    f(x) = 1/2 / n * sum((x[i] - ref_point[i])^2 for i in eachindex(x))
+    function grad!(storage, x)
+        storage .= x
+        storage .-= ref_point
+        storage ./= n
+    end
+    lmo = Hypercube()
+    x0 = FrankWolfe.compute_extreme_point(lmo, -ones(n))
+    tracking_lmo = FrankWolfe.TrackingLMO(lmo)
+    for lazy in (false, true)
+        x, v, primal, dual_gap, trajectory_exact, active_set_exact = FrankWolfe.away_frank_wolfe(f, grad!, tracking_lmo, x0, verbose=true, weak_separation=false, lazy=lazy)
+        tracking_weak = FrankWolfe.TrackingLMO(lmo)
+        x, v, primal, dual_gap, trajectory_weak, active_set_weak = FrankWolfe.away_frank_wolfe(f, grad!, tracking_weak, x0, verbose=true, weak_separation=true, lazy=lazy)
+    end
+end

--- a/test/weak_separation.jl
+++ b/test/weak_separation.jl
@@ -71,7 +71,7 @@ end
     @test w == v
 end
 
-@testset "AFW with weak separation" begin
+@testset "AFW and BPCG with weak separation" begin
     n = 1000
     # reference point to get an optimum on a face
     ref_point = [0.6 + mod(idx, 2) for idx in 1:n]
@@ -88,5 +88,12 @@ end
         tracking_weak = FrankWolfe.TrackingLMO(Hypercube())
         x, v, primal, dual_gap, trajectory_weak, active_set_weak = FrankWolfe.away_frank_wolfe(f, grad!, tracking_weak, x0, verbose=false, weak_separation=true, lazy=lazy)
         @test tracking_lmo.counter <= tracking_weak.counter
+
+        tracking_lmo = FrankWolfe.TrackingLMO(Hypercube())
+        x, v, primal, dual_gap, trajectory_exact, active_set_exact = FrankWolfe.blended_pairwise_conditional_gradient(f, grad!, tracking_lmo, x0, verbose=false, weak_separation=false, lazy=lazy)
+        tracking_weak = FrankWolfe.TrackingLMO(Hypercube())
+        x, v, primal, dual_gap, trajectory_weak, active_set_weak = FrankWolfe.blended_pairwise_conditional_gradient(f, grad!, tracking_weak, x0, verbose=false, weak_separation=true, lazy=lazy)
+        @test tracking_lmo.counter <= tracking_weak.counter
+
     end
 end


### PR DESCRIPTION
introduces weak separation oracles as an abstract interface that other FW algorithms will be able to leverage.

Right now the only weak oracles are cache-based (active set or cache) in the various algorithms. This generalizes the concept to accept oracles including:
- heuristics (no guarantee on the solution)
- approximation algorithms (providing an optimality bound)

