### PR TITLE
Fixes step selection issue in lazy blended pairwise CG

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,6 @@ ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Setfield = "efcf1570-3423-57d1-acb7-fd33fddbac46"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
-TestEnv = "1e6cf692-eddd-4d53-88a5-2d735e33781b"
 TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,7 @@ ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Setfield = "efcf1570-3423-57d1-acb7-fd33fddbac46"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+TestEnv = "1e6cf692-eddd-4d53-88a5-2d735e33781b"
 TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 
 [compat]

--- a/src/pairwise.jl
+++ b/src/pairwise.jl
@@ -300,12 +300,13 @@ function blended_pairwise_conditional_gradient(
                 grad!(gradient, x)
                 dual_gap = fast_dot(gradient, x) - fast_dot(gradient, v)
             end
-            # Note: In the following we differentiate between lazy and non-lazy updates. the reason is that the non-lazy version
-            # does not use the phi but the lazy one heavily depends on it. it is important that the phi is only updated after dropping
+            # Note: In the following, we differentiate between lazy and non-lazy updates.
+            # The reason is that the non-lazy version does not use phi but the lazy one heavily depends on it.
+            # It is important that the phi is only updated after dropping
             # below phi / lazy_tolerance, as otherwise we simply have a "lagging" dual_gap estimate that just slows down convergence.
-            # the logic is as following
-            # for non-lazy: we accept everything and there are no dual steps
-            # for lazy: we accept accept also slightly weaker vertices, those satisfying phi / lazy_tolerance
+            # The logic is as follows:
+            # - for non-lazy: we accept everything and there are no dual steps
+            # - for lazy: we also accept slightly weaker vertices, those satisfying phi / lazy_tolerance
             # this should simplify the criterion.
             # DO NOT CHANGE without good reason and talk to Sebastian first for the logic behind this.
             if !lazy || dual_gap ≥ phi / lazy_tolerance                  

--- a/test/pairwise.jl
+++ b/test/pairwise.jl
@@ -35,7 +35,7 @@ end
         max_iteration=6000,
         line_search=FrankWolfe.Adaptive(),
         print_iter=100,
-        verbose=true,
+        verbose=false,
         epsilon=3e-7,
     )
     @test res_afw[3] ≈ res_bpcg[3]
@@ -74,7 +74,7 @@ end
         x0,
         max_iteration=6000,
         line_search=FrankWolfe.Adaptive(),
-        verbose=true,
+        verbose=false,
         epsilon=3e-7,
         callback=test_callback,
     )

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -416,7 +416,7 @@ end
             line_search=FrankWolfe.Agnostic(),
             print_iter=k / 10,
             memory_mode=FrankWolfe.OutplaceEmphasis(),
-            verbose=true,
+            verbose=false,
         )
 
         @test eltype(x0) == T
@@ -431,7 +431,7 @@ end
             line_search=FrankWolfe.Agnostic(),
             print_iter=k / 10,
             memory_mode=FrankWolfe.InplaceEmphasis(),
-            verbose=true,
+            verbose=false,
         )
 
         @test eltype(x0) == T


### PR DESCRIPTION
note: couldn't run test on my machine as julia-1.9.2 crashes due to a malloc issue:

```
ulia(59061,0x1ff4de080) malloc: *** error for object 0xe00000000000000: pointer being freed was not allocated
julia(59061,0x1ff4de080) malloc: *** set a breakpoint in malloc_error_break to debug

[59061] signal (6): Abort trap: 6
in expression starting at FrankWolfe.jl/test/lmo.jl:386
__pthread_kill at /usr/lib/system/libsystem_kernel.dylib (unknown line)
Allocations: 55868956 (Pool: 55827465; Big: 41491); GC: 81
ERROR: Package FrankWolfe errored during testing (received signal: 6)
```
(maybe something to report separately)