### PR TITLE
dense gradient by default

### DIFF
--- a/src/afw.jl
+++ b/src/afw.jl
@@ -136,6 +136,15 @@ function away_frank_wolfe(
 
     d = similar(x)
 
+    if gradient === nothing
+        gradient = collect(x)
+    end
+    gtemp = if momentum !== nothing
+        similar(gradient)
+    else
+        nothing
+    end
+    
     if verbose
         println("\nAway-step Frank-Wolfe Algorithm.")
         NumType = eltype(x)
@@ -147,24 +156,11 @@ function away_frank_wolfe(
             "GRADIENTTYPE: $grad_type LAZY: $lazy lazy_tolerance: $lazy_tolerance MOMENTUM: $momentum AWAYSTEPS: $away_steps",
         )
         println("Linear Minimization Oracle: $(typeof(lmo))")
-        if memory_mode isa InplaceEmphasis
-            @info("In memory_mode memory iterates are written back into x0!")
-        end
         if (use_extra_vertex_storage || add_dropped_vertices) && extra_vertex_storage === nothing
             @warn(
                 "use_extra_vertex_storage and add_dropped_vertices options are only usable with a extra_vertex_storage storage"
             )
         end
-    end
-
-    # likely not needed anymore as now the iterates are provided directly via the active set
-    if gradient === nothing
-        gradient = similar(x)
-    end
-    gtemp = if momentum !== nothing
-        similar(gradient)
-    else
-        nothing
     end
 
     x = get_active_set_iterate(active_set)

--- a/src/blended_cg.jl
+++ b/src/blended_cg.jl
@@ -136,7 +136,7 @@ function blended_conditional_gradient(
     dual_gap = Inf
     x = active_set.x
     if gradient === nothing
-        gradient = similar(x)
+        gradient = collect(x)
     end
     d = similar(x)
     primal = f(x)
@@ -171,7 +171,6 @@ function blended_conditional_gradient(
         grad_type = typeof(gradient)
         println("GRADIENTTYPE: $grad_type lazy_tolerance: $lazy_tolerance")
         println("Linear Minimization Oracle: $(typeof(lmo))")
-        @info("In memory_mode memory iterates are written back into x0!")
 
         if (use_extra_vertex_storage || add_dropped_vertices) && extra_vertex_storage === nothing
             @warn(
@@ -797,7 +796,7 @@ function simplex_gradient_descent_over_probability_simplex(
 )
     number_of_steps = 0
     x = deepcopy(initial_point)
-    gradient = similar(x)
+    gradient = collect(x)
     reduced_grad!(gradient, x)
     strong_wolfe_gap = strong_frankwolfe_gap_probability_simplex(gradient, x)
     while strong_wolfe_gap > tolerance && t + number_of_steps <= max_iteration

--- a/src/block_coordinate_algorithms.jl
+++ b/src/block_coordinate_algorithms.jl
@@ -154,6 +154,11 @@ function perform_bc_updates(bc_algo::BCFW, f, grad!, lmo, x0)
         @warn("Momentum-averaged gradients should usually be used with agnostic stepsize rules.",)
     end
 
+    # instanciating container for gradient
+    if gradient === nothing
+        gradient = collect(x)
+    end
+    
     if verbose
         println("\nBlock coordinate Frank-Wolfe (BCFW).")
         num_type = eltype(x0[1])
@@ -168,10 +173,6 @@ function perform_bc_updates(bc_algo::BCFW, f, grad!, lmo, x0)
     end
 
     first_iter = true
-    # instanciating container for gradient
-    if gradient === nothing
-        gradient = similar(x)
-    end
     if linesearch_workspace === nothing
         linesearch_workspace = build_linesearch_workspace(line_search, x, gradient) # TODO: might not be really needed - hence hack
     end

--- a/src/fw_algorithms.jl
+++ b/src/fw_algorithms.jl
@@ -68,6 +68,12 @@ function frank_wolfe(
         @warn("Momentum-averaged gradients should usually be used with agnostic stepsize rules.",)
     end
 
+    # instanciating container for gradient
+    if gradient === nothing
+        gradient = collect(x)
+    end
+    
+
     if verbose
         println("\nVanilla Frank-Wolfe Algorithm.")
         NumType = eltype(x0)
@@ -90,10 +96,6 @@ function frank_wolfe(
         end
     end
     first_iter = true
-    # instanciating container for gradient
-    if gradient === nothing
-        gradient = similar(x)
-    end
     if linesearch_workspace === nothing
         linesearch_workspace = build_linesearch_workspace(line_search, x, gradient)
     end
@@ -316,6 +318,10 @@ function lazified_conditional_gradient(
         @warn("Lazification is not known to converge with open-loop step size strategies.")
     end
 
+    if gradient === nothing
+        gradient = collect(x)
+    end
+
     if verbose
         println("\nLazified Conditional Gradient (Frank-Wolfe + Lazification).")
         NumType = eltype(x0)
@@ -336,10 +342,6 @@ function lazified_conditional_gradient(
         else
             x = copyto!(similar(x), x)
         end
-    end
-
-    if gradient === nothing
-        gradient = similar(x)
     end
 
     # container for direction

--- a/src/pairwise.jl
+++ b/src/pairwise.jl
@@ -126,6 +126,10 @@ function blended_pairwise_conditional_gradient(
 
     d = similar(x)
 
+    if gradient === nothing
+        gradient = collect(x)
+    end
+
     if verbose
         println("\nBlended Pairwise Conditional Gradient Algorithm.")
         NumType = eltype(x)
@@ -135,9 +139,6 @@ function blended_pairwise_conditional_gradient(
         grad_type = typeof(gradient)
         println("GRADIENTTYPE: $grad_type LAZY: $lazy lazy_tolerance: $lazy_tolerance")
         println("Linear Minimization Oracle: $(typeof(lmo))")
-        if memory_mode isa InplaceEmphasis
-            @info("In memory_mode memory iterates are written back into x0!")
-        end
         if use_extra_vertex_storage && !lazy
             @info("vertex storage only used in lazy mode")
         end
@@ -146,11 +147,6 @@ function blended_pairwise_conditional_gradient(
                 "use_extra_vertex_storage and add_dropped_vertices options are only usable with a extra_vertex_storage storage"
             )
         end
-    end
-
-    # likely not needed anymore as now the iterates are provided directly via the active set
-    if gradient === nothing
-        gradient = similar(x)
     end
 
     grad!(gradient, x)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -65,7 +65,7 @@ function benchmark_oracles(f, grad!, x_gen, lmo; k=100, nocache=true)
     end
     @showprogress 1 "Testing dual gap... " for i in 1:k
         x = x_gen()
-        gradient = similar(x)
+        gradient = collect(x)
         grad!(gradient, x)
         v = compute_extreme_point(lmo, gradient)
         @timeit to "dual gap" begin
@@ -74,7 +74,7 @@ function benchmark_oracles(f, grad!, x_gen, lmo; k=100, nocache=true)
     end
     @showprogress 1 "Testing update... (Emphasis: OutplaceEmphasis) " for i in 1:k
         x = x_gen()
-        gradient = similar(x)
+        gradient = collect(x)
         grad!(gradient, x)
         v = compute_extreme_point(lmo, gradient)
         gamma = 1 / 2
@@ -85,7 +85,7 @@ function benchmark_oracles(f, grad!, x_gen, lmo; k=100, nocache=true)
     end
     @showprogress 1 "Testing update... (memory_mode: InplaceEmphasis) " for i in 1:k
         x = x_gen()
-        gradient = similar(x)
+        gradient = collect(x)
         grad!(gradient, x)
         v = compute_extreme_point(lmo, gradient)
         gamma = 1 / 2
@@ -100,7 +100,7 @@ function benchmark_oracles(f, grad!, x_gen, lmo; k=100, nocache=true)
             @timeit to "caching 100 points" begin
                 cache = [gen_x() for _ in 1:100]
                 x = gen_x()
-                gradient = similar(x)
+                gradient = collect(x)
                 grad!(gradient, x)
                 v = compute_extreme_point(lmo, gradient)
                 gamma = 1 / 2


### PR DESCRIPTION
sparse gradients are typically a performance foot gun, `gradient = similar(x)` results in a sparse array which means dense operations will be slow. Gradients are now by default a dense array with dimensions matching `x`.

Cleaned up comments and unnecessary printing