### PR TITLE
smoothness fallback

### DIFF
--- a/src/linesearch.jl
+++ b/src/linesearch.jl
@@ -400,7 +400,7 @@ function perform_line_search(
             # if we were not using the relaxed smoothness, we try it first as a stable fallback
             # note that the smoothness estimate is not updated at this iteration.
             if !line_search.relaxed_smoothness
-                linesearch_fallback = copy(line_search)
+                linesearch_fallback = deepcopy(line_search)
                 linesearch_fallback.relaxed_smoothness = true
                 return perform_line_search(
                     linesearch_fallback, t, f, grad!, gradient, x, d, gamma_max, storage, memory_mode;

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -444,7 +444,7 @@ end
             lmo,
             x0,
             max_iteration=k,
-            line_search=FrankWolfe.Adaptive(verbose=false),
+            line_search=FrankWolfe.Adaptive(),
             print_iter=k / 10,
             memory_mode=FrankWolfe.InplaceEmphasis(),
             verbose=true,


### PR DESCRIPTION
uses the safer smoothness estimate as a fallback if numerical trouble occurs