### PR TITLE
Alm minor fixes

### DIFF
--- a/src/block_coordinate_algorithms.jl
+++ b/src/block_coordinate_algorithms.jl
@@ -31,12 +31,12 @@ function select_update_indices(::StochasticUpdate, l)
     return [[rand(1:l)] for i in 1:l]
 end
 
-struct CallbackStateBlockCoordinateMethod{TP,TDV,TDG,XT,VT,TG,FT,GFT,GT}
+struct CallbackStateBlockCoordinateMethod{TP,TDV,TDG,TIN,XT,VT,TG,FT,GFT,GT}
     t::Int
     primal::TP
     dual::TDV
     dual_gap::TDG
-    infeas::Float64
+    infeas::TIN
     time::Float64
     x::XT
     v::VT

--- a/src/linesearch.jl
+++ b/src/linesearch.jl
@@ -297,6 +297,7 @@ Adaptive Step Size strategy from [this paper](https://arxiv.org/abs/1806.05123)
 ```math
     f(x_t + \\gamma_t (x_t - v_t)) - f(x_t) \\leq - \\alpha \\gamma_t \\langle \\nabla f(x_t), x_t - v_t \\rangle + \\alpha^2  \\frac{\\gamma_t^2 \\|x_t - v_t\\|^2}{2} M ~.
 ```
+The parameter `alpha ∈ (0,1]` relaxes the original smoothness condition to mitigate issues with nummerical errors. Its default value is `0.5`.
 The `Adaptive` struct keeps track of the Lipschitz constant estimate `L_est`.
 The keyword argument `relaxed_smoothness` allows testing with an alternative smoothness condition, 
 ```math


### PR DESCRIPTION
Minor fixes of previous pull requests:
- Update docstring of Adaptive Linesearch
- Modifiy type declarations of callbackstate for BCFW in order to run example with rationals or other types than float