### PR TITLE
BPCG - Real dual gap in Post Processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ julia> p_opt
  0.3333333286623478
 ```
 
-Note that active-set based methods like `Away-Frank-Wolfe` and `Blended Pairwise Conditional Gradient` also include a post processing step. 
+Note that active-set based methods like Away Frank-Wolfe and Blended Pairwise Conditional Gradient also include a post processing step. 
 In post-processing all values are recomputed and in particular the dual gap is computed at the current FW vertex, which might be slightly larger than the best dual gap observed as the gap is not monotonic. This is expected behavior.
 
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ julia> p_opt
  0.3333333286623478
 ```
 
+Note that active-set based methods like `Away-Frank-Wolfe` and `Blended Pairwise Conditional Gradient` also include a post processing step. 
+In post-processing all values are recomputed and in particular the dual gap is computed at the current FW vertex, which might be slightly larger than the best dual gap observed as the gap is not monotonic. This is expected behavior.
+
+
 ## Documentation and examples
 
 To explore the content of the package, go to the [documentation](https://zib-iol.github.io/FrankWolfe.jl/dev/).

--- a/src/blended_pairwise.jl
+++ b/src/blended_pairwise.jl
@@ -459,7 +459,6 @@ function blended_pairwise_conditional_gradient(
         v = compute_extreme_point(lmo, gradient)
         primal = f(x)
         dual_gap = fast_dot(x, gradient) - fast_dot(v, gradient)
-        dual_gap = dual_gap < phi ? dual_gap : phi 
     end
     tt = pp
     tot_time = (time_ns() - time_start) / 1e9


### PR DESCRIPTION
Show the real dual gap in the Post processing step.

Added a note in the Documentation that the dual gap is not monotonous. Thus, the post processing step might yield a slightly larger dual gap.