### PR TITLE
Out-of-bounds in pairwise variant

### DIFF
--- a/src/pairwise.jl
+++ b/src/pairwise.jl
@@ -261,19 +261,19 @@ function pairwise_frank_wolfe(
                 active_set,
                 -gamma,
                 away_vertex,
-                true,
+                false,
                 away_index,
                 add_dropped_vertices=use_extra_vertex_storage,
                 vertex_storage=extra_vertex_storage,
             )
-            if add_dropped_vertices && gamma == gamma_max
+            if add_dropped_vertices && gamma ≈ gamma_max
                 for vtx in active_set.atoms
                     if vtx != v
                         push!(extra_vertex_storage, vtx)
                     end
                 end
             end
-            # fw update 
+            # fw update
             active_set_update!(active_set, gamma, fw_vertex, renorm, fw_index)
         end
 


### PR DESCRIPTION
Dominik identified the following problem in pairwise:
```julia
using FrankWolfe
using LinearAlgebra
using StableRNGs

rng = StableRNG(09382173)
n = 100

xpi = reshape(rand(rng, n*n), n, n)

function f(x)
    return norm(x .- xpi)^2 / n^2
end

function grad!(storage, x)
    return @. storage = (2 * (x - xpi)) / n^2
end

lmo = FrankWolfe.BirkhoffPolytopeLMO()
x0 = compute_extreme_point(lmo, reshape(rand(rng, n*n), n, n))
act_set = FrankWolfe.ActiveSet([(BigFloat(1.0), x0)])
FrankWolfe.pairwise_frank_wolfe(f, grad!, lmo, copy(act_set); verbose=true)
```

This tries to access an undefined reference as the first away update deletes an atom with small weight, but then tries to access it in the fw update.
This was most likely a typo as the comment above the first update explicitly states that renormalisation only concerns the fw update.