### PR TITLE
Clean active set constructors

### DIFF
--- a/src/active_set.jl
+++ b/src/active_set.jl
@@ -27,17 +27,7 @@ ActiveSet{AT,R}() where {AT,R} = ActiveSet{AT,R,Vector{float(eltype(AT))}}([], [
 ActiveSet{AT}() where {AT} = ActiveSet{AT,Float64,Vector{float(eltype(AT))}}()
 
 function ActiveSet(tuple_values::AbstractVector{Tuple{R,AT}}) where {AT,R}
-    n = length(tuple_values)
-    weights = Vector{R}(undef, n)
-    atoms = Vector{AT}(undef, n)
-    @inbounds for idx in 1:n
-        weights[idx] = tuple_values[idx][1]
-        atoms[idx] = tuple_values[idx][2]
-    end
-    x = similar(atoms[1], float(eltype(atoms[1])))
-    as = ActiveSet{AT,R,typeof(x)}(weights, atoms, x)
-    compute_active_set_iterate!(as)
-    return as
+    return ActiveSet{AT,R}(tuple_values)
 end
 
 function ActiveSet{AT,R}(tuple_values::AbstractVector{<:Tuple{<:Number,<:Any}}) where {AT,R}
@@ -48,7 +38,7 @@ function ActiveSet{AT,R}(tuple_values::AbstractVector{<:Tuple{<:Number,<:Any}}) 
         weights[idx] = tuple_values[idx][1]
         atoms[idx] = tuple_values[idx][2]
     end
-    x = similar(tuple_values[1][2], float(eltype(tuple_values[1][2])))
+    x = similar(atoms[1], float(eltype(atoms[1])))
     as = ActiveSet{AT,R,typeof(x)}(weights, atoms, x)
     compute_active_set_iterate!(as)
     return as

--- a/src/active_set_quadratic.jl
+++ b/src/active_set_quadratic.jl
@@ -54,28 +54,7 @@ function ActiveSetQuadratic(tuple_values::AbstractVector{Tuple{R,AT}}, grad!::Fu
 end
 
 function ActiveSetQuadratic(tuple_values::AbstractVector{Tuple{R,AT}}, A::H, b) where {AT,R,H}
-    n = length(tuple_values)
-    weights = Vector{R}(undef, n)
-    atoms = Vector{AT}(undef, n)
-    dots_x = zeros(R, n)
-    dots_A = Vector{Vector{R}}(undef, n)
-    dots_b = Vector{R}(undef, n)
-    weights_prev = zeros(R, n)
-    modified = trues(n)
-    @inbounds for idx in 1:n
-        weights[idx] = tuple_values[idx][1]
-        atoms[idx] = tuple_values[idx][2]
-        dots_A[idx] = Vector{R}(undef, idx)
-        for idy in 1:idx
-            dots_A[idx][idy] = fast_dot(A * atoms[idx], atoms[idy])
-        end
-        dots_b[idx] = fast_dot(b, atoms[idx])
-    end
-    x = similar(b)
-    as = ActiveSetQuadratic(weights, atoms, x, A, b, dots_x, dots_A, dots_b, weights_prev, modified)
-
-    compute_active_set_iterate!(as)
-    return as
+    return ActiveSetQuadratic{AT,R}(tuple_values, A, b)
 end
 
 function ActiveSetQuadratic{AT,R}(tuple_values::AbstractVector{<:Tuple{<:Number,<:Any}}, grad!::Function) where {AT,R}

--- a/src/active_set_quadratic.jl
+++ b/src/active_set_quadratic.jl
@@ -74,15 +74,24 @@ function ActiveSetQuadratic{AT,R}(tuple_values::AbstractVector{<:Tuple{<:Number,
     @inbounds for idx in 1:n
         weights[idx] = tuple_values[idx][1]
         atoms[idx] = tuple_values[idx][2]
-        dots_A[idx] = Vector{R}(undef, idx)
-        for idy in 1:idx
-            dots_A[idx][idy] = fast_dot(A * atoms[idx], atoms[idy])
-        end
-        dots_b[idx] = fast_dot(b, atoms[idx])
     end
     x = similar(b)
     as = ActiveSetQuadratic{AT,R,typeof(x),H}(weights, atoms, x, A, b, dots_x, dots_A, dots_b, weights_prev, modified)
+    reset_quadratic_dots!(as)
     compute_active_set_iterate!(as)
+    return as
+end
+
+# should only be called upon construction
+# for active sets with a large number of atoms, this function becomes very costly
+function reset_quadratic_dots!(as::ActiveSetQuadratic{AT,R}) where {AT,R}
+    @inbounds for idx in 1:length(as)
+        as.dots_A[idx] = Vector{R}(undef, idx)
+        for idy in 1:idx
+            as.dots_A[idx][idy] = fast_dot(as.A * as.atoms[idx], as.atoms[idy])
+        end
+        as.dots_b[idx] = fast_dot(as.b, as.atoms[idx])
+    end
     return as
 end
 


### PR DESCRIPTION
The constructors of `ActiveSet` and `ActiveSetQuadratic` contained quite some redundancy.
This PR fixes this and isolates the computation of the `dots` fields in `ActiveSetQuadratic`.
Note that the computation of the elements in `dots_x` are not computed in this function as they are assumed to be updated in `active_set_argminmax`.