### PR TITLE
Example with ADOLC

### DIFF
--- a/examples/adolc_example.jl
+++ b/examples/adolc_example.jl
@@ -4,13 +4,13 @@ using LinearAlgebra
 using Test
 
 ## Data setup
-n = Int(100)
+n = Int(10000)
 
 xpi = rand(n);
 total = sum(xpi);
 const xp = xpi ./ total;
 
-f(x) = norm(x - xp)^2
+f(x) = sum(abs2, x-xp)
 
 println("Automatic differentiation")
 
@@ -41,6 +41,8 @@ x_au, _, primal_au, dual_gap_au, _ = FrankWolfe.frank_wolfe(
 );
 
 println("\nHandwritten Gradient")
+
+f(x) = norm(x-xp)^2
 
 function grad!(storage, x)
     @. storage = 2 * (x - xp)


### PR DESCRIPTION
Works well if `n` is small. But even for `n=50`, the gradient computation seems to be instable. 
For `n=500`, it errors with 
```
Vanilla Frank-Wolfe Algorithm.
MEMORY_MODE: FrankWolfe.InplaceEmphasis() STEPSIZE: Adaptive{Float64, Int64} EPSILON: 1.0e-7 MAXITERATION: 10000 TYPE: Float64
MOMENTUM: nothing GRADIENTTYPE: Nothing
LMO: FrankWolfe.ProbabilitySimplexOracle{Float64}
[ Info: In memory_mode memory iterates are written back into x0!
ADOL-C Warning: Branch switch detected in comparison (operator le_zero).
Forward sweep aborted! Retaping recommended!

-------------------------------------------------------------------------------------------------
  Type     Iteration         Primal           Dual       Dual Gap           Time         It/sec
-------------------------------------------------------------------------------------------------
     I             1   6.248921e+00   6.248921e+00   0.000000e+00   0.000000e+00            Inf
ADOL-C Warning: Branch switch detected in comparison (operator le_zero).
Forward sweep aborted! Retaping recommended!
  Last             1   6.248921e+00   6.248921e+00   0.000000e+00   9.962060e-01   1.003808e+00
-------------------------------------------------------------------------------------------------
```