### PR TITLE
if dual_gap below epsilon dont enter update block

### DIFF
--- a/src/blended_pairwise.jl
+++ b/src/blended_pairwise.jl
@@ -210,7 +210,7 @@ function blended_pairwise_conditional_gradient(
         end
         # minor modification from original paper for improved sparsity
         # (proof follows with minor modification when estimating the step)
-        if local_gap ≥ phi / lazy_tolerance
+        if local_gap ≥ phi / lazy_tolerance && local_gap ≥ epsilon
             d = muladd_memory_mode(memory_mode, d, a, v_local)
             vertex_taken = v_local
             gamma_max = a_lambda
@@ -309,7 +309,7 @@ function blended_pairwise_conditional_gradient(
             # - for lazy: we also accept slightly weaker vertices, those satisfying phi / lazy_tolerance
             # this should simplify the criterion.
             # DO NOT CHANGE without good reason and talk to Sebastian first for the logic behind this.
-            if !lazy || dual_gap ≥ phi / lazy_tolerance
+            if (dual_gap ≥ epsilon) && (!lazy || dual_gap ≥ phi / lazy_tolerance)
                 d = muladd_memory_mode(memory_mode, d, x, v)
 
                 gamma = perform_line_search(

--- a/src/block_coordinate_algorithms.jl
+++ b/src/block_coordinate_algorithms.jl
@@ -355,7 +355,7 @@ function update_iterate(
 
     # minor modification from original paper for improved sparsity
     # (proof follows with minor modification when estimating the step)
-    if local_gap > max(s.phi / s.lazy_tolerance, 0) # Robust condition to not drop the zero-vector if the dual_gap is negative by inaccuracy
+    if local_gap > s.phi / s.lazy_tolerance && local_gap ≥ epsilon
         d = muladd_memory_mode(memory_mode, d, a, v_local)
         vertex_taken = v_local
         gamma_max = a_lambda
@@ -401,7 +401,7 @@ function update_iterate(
             dual_gap = fast_dot(gradient, x) - fast_dot(gradient, v)
         end
 
-        if !s.lazy || dual_gap ≥ s.phi / s.lazy_tolerance
+        if (dual_gap ≥ epsilon) && (!s.lazy || dual_gap ≥ s.phi / s.lazy_tolerance)
 
             d = muladd_memory_mode(memory_mode, d, x, v)
 


### PR DESCRIPTION
In BPCG, if the dual_gap is below epsilon already, we should not enter the block updating x_t, the conditions should be shortcircuited