### PR TITLE
Add the adaptation from the Secant experiments

### DIFF
--- a/src/linesearch.jl
+++ b/src/linesearch.jl
@@ -786,6 +786,8 @@ function perform_line_search(
     return γ
 end
 
+Base.print(io::IO, ::Adaptive) = print(io, "Adaptive")
+
 """
     MonotonicStepSize{F}
 

--- a/src/linesearch.jl
+++ b/src/linesearch.jl
@@ -515,8 +515,8 @@ mutable struct AdaptiveZerothOrder{T,TT,F} <: LineSearchMethod
     domain_oracle::F
 end
 
-AdaptiveZerothOrder(eta::T, tau::TT) where {T,TT} =
-    AdaptiveZerothOrder{T,TT}(eta, tau, T(Inf), T(1e10), T(0.5), true, false, x->true)
+AdaptiveZerothOrder(eta::T, tau::TT; domain_oracle=x->true) where {T,TT} =
+    AdaptiveZerothOrder{T,TT, typeof(domain_oracle)}(eta, tau, T(Inf), T(1e10), T(0.5), true, false, domain_oracle)
 
 AdaptiveZerothOrder(;
     eta=0.9,

--- a/src/linesearch.jl
+++ b/src/linesearch.jl
@@ -675,8 +675,8 @@ mutable struct Adaptive{T,TT,F} <: LineSearchMethod
     domain_oracle::F
 end
 
-Adaptive(eta::T, tau::TT) where {T,TT} =
-    Adaptive{T,TT}(eta, tau, T(Inf), T(1e10), true, false, x->true)
+Adaptive(eta::T, tau::TT; domain_oracle=x->true) where {T,TT} =
+    Adaptive{T,TT, typeof(domain_oracle)}(eta, tau, T(Inf), T(1e10), true, false, domain_oracle)
 
 Adaptive(; eta=0.9, tau=2, L_est=Inf, max_estimate=1e10, verbose=true, relaxed_smoothness=false, domain_oracle=x->true) =
     Adaptive(eta, tau, L_est, max_estimate, verbose, relaxed_smoothness, domain_oracle)


### PR DESCRIPTION
- No fallback by default.
- If we stop the loop because the direction and gradient are too much aligned, we do not need to fallback.
- Domain oracle for both `Adaptive` and `AdaptiveZerothOrder`