### PR TITLE
Adding details for getting started in the documentations

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The main function is **`FrankWolfe.frank_wolfe`** and it requires:
 ```julia
 julia> using FrankWolfe
 
-# #objective function f(p) = p_1^2 + ... + p_n^2
+# objective function f(p) = p_1^2 + ... + p_n^2
 julia> f(p) = sum(abs2, p)
 
 # #in-place gradient computation for f thanks to '.='

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ julia> p_opt
  0.3333333286623478
 ```
 
-**Note** that active-set based methods like Away Frank-Wolfe and Blended Pairwise Conditional Gradient also include a post processing step. 
+**Note** that active-set based methods like the Away-step Frank-Wolfe and Blended Pairwise Conditional Gradients also include a post-processing step. 
 In post-processing all values are recomputed and in particular the dual gap is computed at the current FW vertex, which might be slightly larger than the best dual gap observed as the gap is not monotonic. This is expected behavior.
 
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ where $`Δ(n)= \{p \in R^n_{\geq 0} | p_1 + \dots + p_n =1\}`$ is the _probabili
 Using `FrankWolfe.jl`, let's write a minimal code solving this problem in dimension $n=3$.
 The main function is **`FrankWolfe.frank_wolfe`** and it requires: 
 
-* an **function `f`** that computes the values of the objective function $f$;
+* a **function `f`** that computes the values of the objective function $f$;
 * a **function `grad!`** that computes in-place the gradient of the objective function $f$;
 * a **subtype of `FrankWolfe.LinearMinimizationOracle`** for which a method of        `FrankWolfe.compute_extreme_point` has been implemented (see [here](https://zib-iol.github.io/FrankWolfe.jl/dev/basics/#Linear-Minimization-Oracles));
 * a **starting vector `p0`**.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@ This package is a toolbox for Frank-Wolfe and conditional gradients algorithms.
 
 ## Overview
 
-Frank-Wolfe algorithms were designed to solve optimization problems of the form $\min_{x ∈ C} f(x)$, where $f$ is a differentiable convex function and $C$ is a convex and compact set.
+Frank-Wolfe algorithms were designed to solve optimization problems of the form 
+```math
+\min_{x ∈ C} f(x),
+```
+where $f$ is a differentiable convex function and $C$ is a convex and compact set.
 They are especially useful when we know how to optimize a linear function over $C$ in an efficient way.
 
 A paper presenting the package with mathematical explanations and numerous examples can be found here:
@@ -34,20 +38,36 @@ Pkg.add(url="https://github.com/ZIB-IOL/FrankWolfe.jl", rev="master")
 
 ## Getting started
 
-Let's say we want to minimize the Euclidian norm over the probability simplex `Δ`. Using `FrankWolfe.jl`, this is what the code looks like (in dimension 3):
+Let's say we want to solve the following minimization problem 
+```math
+\min_{p \in  Δ(n)} p_1^2 + \dots + p_n^2,
+```
+where $`Δ(n)= \{p \in R^n_{\geq 0} | p_1 + \dots + p_n =1\}`$ is the _probability simplex_.
+
+Using `FrankWolfe.jl`, let's write a minimal code solving this problem in dimension $n=3$.
+The main function is **`FrankWolfe.frank_wolfe`** and it requires: 
+
+* an **function `f`** that computes the values of the objective function $f$;
+* a **function `grad!`** that computes in-place the gradient of the objective function $f$;
+* a **subtype of `FrankWolfe.LinearMinimizationOracle`** for which a method of        `FrankWolfe.compute_extreme_point` has been implemented (see [here](https://zib-iol.github.io/FrankWolfe.jl/dev/basics/#Linear-Minimization-Oracles));
+* a **starting vector `p0`**.
 
 ```julia
 julia> using FrankWolfe
 
-julia> f(p) = sum(abs2, p)  # objective function
+# #objective function f(p) = p_1^2 + ... + p_n^2
+julia> f(p) = sum(abs2, p)
 
-julia> grad!(storage, p) = storage .= 2p  # in-place gradient computation
+# #in-place gradient computation for f thanks to '.='
+julia> grad!(storage, p) = storage .= 2p  
 
-# # function d ⟼ argmin ⟨p,d⟩ st. p ∈ Δ
+# #pre-defined type for which a method computes a solution of min ⟨p,d⟩ st. p ∈ Δ 
 julia> lmo = FrankWolfe.ProbabilitySimplexOracle(1.)
 
+# #starting vector (of dimension n=3)
 julia> p0 = [1., 0., 0.]
 
+# #an optimal solution is returned in p_opt
 julia> p_opt, _ = frank_wolfe(f, grad!, lmo, p0; verbose=true);
 
 Vanilla Frank-Wolfe Algorithm.
@@ -69,7 +89,7 @@ julia> p_opt
  0.3333333286623478
 ```
 
-Note that active-set based methods like Away Frank-Wolfe and Blended Pairwise Conditional Gradient also include a post processing step. 
+**Note** that active-set based methods like Away Frank-Wolfe and Blended Pairwise Conditional Gradient also include a post processing step. 
 In post-processing all values are recomputed and in particular the dual gap is computed at the current FW vertex, which might be slightly larger than the best dual gap observed as the gap is not monotonic. This is expected behavior.
 
 

--- a/README.md
+++ b/README.md
@@ -58,16 +58,16 @@ julia> using FrankWolfe
 # objective function f(p) = p_1^2 + ... + p_n^2
 julia> f(p) = sum(abs2, p)
 
-# #in-place gradient computation for f thanks to '.='
+# in-place gradient computation for f thanks to '.='
 julia> grad!(storage, p) = storage .= 2p  
 
 # pre-defined type implementing the linear minimization oracle interface for the simplex
 julia> lmo = FrankWolfe.ProbabilitySimplexOracle(1.)
 
-# #starting vector (of dimension n=3)
+# starting vector (of dimension n=3)
 julia> p0 = [1., 0., 0.]
 
-# #an optimal solution is returned in p_opt
+# an optimal solution is returned in p_opt
 julia> p_opt, _ = frank_wolfe(f, grad!, lmo, p0; verbose=true);
 
 Vanilla Frank-Wolfe Algorithm.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ julia> f(p) = sum(abs2, p)
 # #in-place gradient computation for f thanks to '.='
 julia> grad!(storage, p) = storage .= 2p  
 
-# #pre-defined type for which a method computes a solution of min ⟨p,d⟩ st. p ∈ Δ 
+# pre-defined type implementing the linear minimization oracle interface for the simplex
 julia> lmo = FrankWolfe.ProbabilitySimplexOracle(1.)
 
 # #starting vector (of dimension n=3)

--- a/docs/src/basics.md
+++ b/docs/src/basics.md
@@ -33,7 +33,7 @@ Several common implementations of LMOS s are available out-of-the-box:
 See [Combettes, Pokutta (2021)](https://arxiv.org/abs/2101.10040) for references on most LMOs implemented in the package and their comparison with projection operators.
 
 ### The MathOptLMO
-You can use an oracle defined via a Linear Programming solver (e.g. `SCIP` or `HiGHS`) with `MathOptInferface`: see [`FrankWolfe.MathOptLMO`](@ref).
+You can use an oracle defined via a Linear Programming solver (e.g. `SCIP` or `HiGHS`) with [MathOptInferface](https://github.com/jump-dev/MathOptInterface.jl): see [`FrankWolfe.MathOptLMO`](@ref).
 
 ### Wrapper to combine LMOs
 We provide wrappers to combine oracles easily, for example [`FrankWolfe.ProductLMO`](@ref) for product of oracles or [`FrankWolfe.SubspaceLMO`](@ref) for projections composed with oracles.

--- a/docs/src/basics.md
+++ b/docs/src/basics.md
@@ -18,7 +18,7 @@ These routines work by solving a sequence of linear subproblems:
 The Linear Minimization Oracle (LMO) is a key component, which is called at each iteration of the FW algorithm. Given a direction $d$, it returns an optimal vertex of the feasible set:
 
 ```math
-v \in \arg \min_{x\in \mathcal{C}} \langle d,x \rangle.
+v \in \argmin_{x\in \mathcal{C}} \langle d,x \rangle.
 ```
 
 

--- a/docs/src/basics.md
+++ b/docs/src/basics.md
@@ -36,7 +36,7 @@ See [Combettes, Pokutta (2021)](https://arxiv.org/abs/2101.10040) for references
 You can use an oracle defined via a Linear Programming solver (e.g. `SCIP` or `HiGHS`) with `MathOptInferface`: see [`FrankWolfe.MathOptLMO`](@ref).
 
 ### Wrapper to combine LMOs
-We provide wrappers to combine oracles easily, for example in a product.
+We provide wrappers to combine oracles easily, for example [`FrankWolfe.ProductLMO`](@ref) for product of oracles or [`FrankWolfe.SubspaceLMO`](@ref) for projections composed with oracles.
 
 ### User-defined LMOs
 If you want use  your own custom LMO `MyLMO` in the algorithms provided here, it

--- a/docs/src/basics.md
+++ b/docs/src/basics.md
@@ -22,7 +22,7 @@ v \in \arg \min_{x\in \mathcal{C}} \langle d,x \rangle.
 ```
 
 
-### Pre-defined LMOs
+### Pre-defined LMO for key feasible sets
 
 Several common implementations of LMOS s are available out-of-the-box:
 
@@ -32,8 +32,13 @@ Several common implementations of LMOS s are available out-of-the-box:
   
 See [Combettes, Pokutta (2021)](https://arxiv.org/abs/2101.10040) for references on most LMOs implemented in the package and their comparison with projection operators.
 
-### Custom LMOs
+### The MathOptLMO
+You can use an oracle defined via a Linear Programming solver (e.g. `SCIP` or `HiGHS`) with `MathOptInferface`: see [`FrankWolfe.MathOptLMO`](@ref).
 
+### Wrapper to combine LMOs
+We provide wrappers to combine oracles easily, for example in a product.
+
+### User-defined LMOs
 If you want use  your own custom LMO `MyLMO` in the algorithms provided here, it
 is required that
 * `MyLMO` be a subtype of [`FrankWolfe.LinearMinimizationOracle`](@ref);
@@ -46,11 +51,6 @@ Note that the constraint set $\mathcal{C}$ defined by `MyLMO` doesn't have to be
 Indeed, all we need is to minimize a linear function over $\mathcal{C}$, which does not necessarily require an explicit representation of $\mathcal{C}$.
 Even black box minimization procedures can be considered!
 
-### Interfaces for LMO
- 
-1. You can use an oracle defined via a Linear Programming solver (e.g. `SCIP` or `HiGHS`) with `MathOptInferface`: see [`FrankWolfe.MathOptLMO`](@ref).
-
-2. We provide wrappers to combine oracles easily, for example in a product.
 
 ## Optimization algorithms
 

--- a/docs/src/basics.md
+++ b/docs/src/basics.md
@@ -39,7 +39,7 @@ You can use an oracle defined via a Linear Programming solver (e.g. `SCIP` or `H
 We provide wrappers to combine oracles easily, for example [`FrankWolfe.ProductLMO`](@ref) for product of oracles or [`FrankWolfe.SubspaceLMO`](@ref) for projections composed with oracles.
 
 ### User-defined LMOs
-If you want use  your own custom LMO `MyLMO` in the algorithms provided here, it
+If you want use your own custom LMO `MyLMO` in the algorithms provided here, it
 is required that
 * `MyLMO` be a subtype of [`FrankWolfe.LinearMinimizationOracle`](@ref);
 * the method `FrankWolfe.compute_extreme_point` (see below) be defined and minimize $v \mapsto \langle d, v \rangle$ over the set $\mathcal{C}$ defined by the custom LMO `MyLMO`.

--- a/docs/src/basics.md
+++ b/docs/src/basics.md
@@ -42,7 +42,7 @@ is required that
 FrankWolfe.compute_extreme_point(lmo::MyLMO, direction; v, kwargs...) -> v
 ```
 
-Note that the constraint set $\mathcal{C}$ defined by `MyLMO` doesn't have to be represented explicitly.
+Note that the constraint set $\mathcal{C}$ defined by `MyLMO` doesn't have to be represented explicitly, e.g., as a set of inequalities.
 Indeed, all we need is to minimize a linear function over $\mathcal{C}$, which does not necessarily require an explicit representation of $\mathcal{C}$.
 Even black box minimization procedures can be considered!
 

--- a/docs/src/basics.md
+++ b/docs/src/basics.md
@@ -21,30 +21,36 @@ The Linear Minimization Oracle (LMO) is a key component, which is called at each
 v \in \arg \min_{x\in \mathcal{C}} \langle d,x \rangle.
 ```
 
-### Custom LMOs
-
-To be used by the algorithms provided here, an LMO must be a subtype of [`FrankWolfe.LinearMinimizationOracle`](@ref) and implement the following method:
-
-```julia
-compute_extreme_point(lmo::LMO, direction; kwargs...) -> v
-```
-
-This method should minimize $v \mapsto \langle d, v \rangle$ over the set $\mathcal{C}$ defined by the LMO.
-Note that this means the set $\mathcal{C}$ doesn't have to be represented explicitly: all we need is to be able to minimize a linear function over it, even if the minimization procedure is a black box.
 
 ### Pre-defined LMOs
 
-If you don't want to define your LMO manually, several common implementations are available out-of-the-box:
+Several common implementations of LMOS s are available out-of-the-box:
 
-- Simplices: unit simplex, probability simplex
-- Balls in various norms
-- Polytopes: K-sparse, Birkhoff
-
-You can use an oracle defined via a Linear Programming solver (e.g. `SCIP` or `HiGHS`) with `MathOptInferface`: see [`FrankWolfe.MathOptLMO`](@ref).
-
-Finally, we provide wrappers to combine oracles easily, for example in a product.
-
+- **simplices**: unit simplex [`FrankWolfe.UnitSimplexOracle`](@ref) , probability simplex [`FrankWolfe.ProbabilitySimplexOracle`](@ref);
+- **balls** in various norms [`FrankWolfe.LpNormLMO`](@ref);
+- **polytopes**: K-sparse [`FrankWolfe.KSparseLMO`](@ref) , Birkhoff [`FrankWolfe.BirkhoffPolytopeLMO `](@ref).
+  
 See [Combettes, Pokutta (2021)](https://arxiv.org/abs/2101.10040) for references on most LMOs implemented in the package and their comparison with projection operators.
+
+### Custom LMOs
+
+If you want use  your own custom LMO `MyLMO` in the algorithms provided here, it
+is required that
+* `MyLMO` be a subtype of [`FrankWolfe.LinearMinimizationOracle`](@ref);
+* the method `FrankWolfe.compute_extreme_point` (see below) be defined and minimize $v \mapsto \langle d, v \rangle$ over the set $\mathcal{C}$ defined by the custom LMO `MyLMO`.
+```julia
+FrankWolfe.compute_extreme_point(lmo::MyLMO, direction; v, kwargs...) -> v
+```
+
+Note that the constraint set $\mathcal{C}$ defined by `MyLMO` doesn't have to be represented explicitly.
+Indeed, all we need is to minimize a linear function over $\mathcal{C}$, which does not necessarily require an explicit representation of $\mathcal{C}$.
+Even black box minimization procedures can be considered!
+
+### Interfaces for LMO
+ 
+1. You can use an oracle defined via a Linear Programming solver (e.g. `SCIP` or `HiGHS`) with `MathOptInferface`: see [`FrankWolfe.MathOptLMO`](@ref).
+
+2. We provide wrappers to combine oracles easily, for example in a product.
 
 ## Optimization algorithms
 

--- a/docs/src/reference/2_lmo.md
+++ b/docs/src/reference/2_lmo.md
@@ -2,7 +2,7 @@
 
 The Linear Minimization Oracle (LMO) is a key component called at each iteration of the FW algorithm. Given ``d\in \mathcal{X}``, it returns a vertex of the feasible set:
 ```math
-v\in \arg \min_{x\in \mathcal{C}} \langle d,x \rangle.
+v\in \argmin_{x\in \mathcal{C}} \langle d,x \rangle.
 ```
 
 See [Combettes, Pokutta 2021](https://arxiv.org/abs/2101.10040) for references on most LMOs

--- a/docs/src/reference/2_lmo.md
+++ b/docs/src/reference/2_lmo.md
@@ -2,7 +2,7 @@
 
 The Linear Minimization Oracle (LMO) is a key component called at each iteration of the FW algorithm. Given ``d\in \mathcal{X}``, it returns a vertex of the feasible set:
 ```math
-v\in \argmin_{x\in \mathcal{C}} \langle d,x \rangle.
+v\in \arg \min_{x\in \mathcal{C}} \langle d,x \rangle.
 ```
 
 See [Combettes, Pokutta 2021](https://arxiv.org/abs/2101.10040) for references on most LMOs


### PR DESCRIPTION
I propose some additions in the documentation to help new users to have a minimal working code using `FrankWolfe.jl`.

Generally, I have added more details in **Getting started**  in `README.md` and in **Linear Minimization Oracles**  in `docs/src/basics.md`.

* Writing toy example explicitely in **Getting started** in `README.md`.
* Listing the mandatory arguments for `FrankWolfe.frank_wolfe` in **Getting started** in `README.md`.
* Re-organizing subsections in **Linear Minimization Oracles**  in `docs/src/basics.md`.
* Adding the names of pre-defined LMOs in **Linear Minimization Oracles**  in `docs/src/basics.md`.
* Adding the mandatory keyword argument `v` in the signature of `FrankWolfe.compute_extreme_point` in **Linear Minimization Oracles**  in `docs/src/basics.md`.