### PR TITLE
Minor fix in BCG.

### DIFF
--- a/src/blended_cg.jl
+++ b/src/blended_cg.jl
@@ -972,7 +972,7 @@ function simplex_gradient_descent_over_convex_hull(
         end
         # TODO at some point avoid materializing both x and y
         x = copy(active_set.x)
-        η = max(0, η)
+        η = isfinite(η) ? max(0, η) : 0
         @. active_set.weights -= η * d
         y = copy(compute_active_set_iterate!(active_set))
         number_of_steps += 1


### PR DESCRIPTION
If the dual gap is smaller than epsilon from the get-go, we do one iteration. However, the direction may then be 0.0 and \eta in the simplex descent step stay infinite. 