### PR TITLE
Add initial dual_gap

### DIFF
--- a/src/blended_pairwise.jl
+++ b/src/blended_pairwise.jl
@@ -156,6 +156,7 @@ function blended_pairwise_conditional_gradient(
     # if !lazy, phi is maintained as the global dual gap
     phi = max(0, fast_dot(x, gradient) - fast_dot(v, gradient))
     local_gap = zero(phi)
+    dual_gap = phi
     gamma = one(phi)
 
     if linesearch_workspace === nothing


### PR DESCRIPTION
Bug in BPCG: The dual gap was never initialized if the start point passed the termination criterion and the last vertex was not computed. This would lead to an error in the last callback call.