### PR TITLE
Document keyword arguments

### DIFF
--- a/src/FrankWolfe.jl
+++ b/src/FrankWolfe.jl
@@ -23,6 +23,7 @@ import Arpack
 export frank_wolfe, lazified_conditional_gradient, away_frank_wolfe
 export blended_conditional_gradient, compute_extreme_point
 
+include("docstrings.jl")
 include("abstract_oracles.jl")
 include("defs.jl")
 include("utils.jl")

--- a/src/abstract_oracles.jl
+++ b/src/abstract_oracles.jl
@@ -1,9 +1,13 @@
 
 """
+    LinearMinimizationOracle
+
 Supertype for linear minimization oracles.
 
 All LMOs must implement `compute_extreme_point(lmo::LMO, direction)`
 and return a vector `v` of the appropriate type.
+
+See also: [`compute_extreme_point`](@ref).
 """
 abstract type LinearMinimizationOracle end
 

--- a/src/afw.jl
+++ b/src/afw.jl
@@ -1,11 +1,17 @@
 
 """
-    away_frank_wolfe(f, grad!, lmo, x0; ...)
+    away_frank_wolfe(f, grad!, lmo, x0; kwargs...)
 
 Frank-Wolfe with away steps.
 The algorithm maintains the current iterate as a convex combination of vertices in the
 [`FrankWolfe.ActiveSet`](@ref) data structure.
 See [M. Besançon, A. Carderera and S. Pokutta 2021](https://arxiv.org/abs/2104.06675) for illustrations of away steps.
+
+$COMMON_ARGS
+
+$COMMON_KWARGS
+
+$RETURN_ACTIVESET
 """
 function away_frank_wolfe(
     f,

--- a/src/blended_cg.jl
+++ b/src/blended_cg.jl
@@ -1,6 +1,6 @@
 
 """
-    blended_conditional_gradient(f, grad!, lmo, x0)
+    blended_conditional_gradient(f, grad!, lmo, x0; kwargs...)
 
 Entry point for the Blended Conditional Gradient algorithm.
 See Braun, Gábor, et al. "Blended conditonal gradients" ICML 2019.
@@ -8,6 +8,12 @@ The method works on an active set like [`FrankWolfe.away_frank_wolfe`](@ref),
 performing gradient descent over the convex hull of active vertices,
 removing vertices when their weight drops to 0 and adding new vertices
 by calling the linear oracle in a lazy fashion.
+
+$COMMON_ARGS
+
+$COMMON_KWARGS
+
+$RETURN_ACTIVESET
 """
 function blended_conditional_gradient(
     f,

--- a/src/blended_pairwise.jl
+++ b/src/blended_pairwise.jl
@@ -4,6 +4,12 @@
 Implements the BPCG algorithm from [Tsuji, Tanaka, Pokutta (2021)](https://arxiv.org/abs/2110.12650).
 The method uses an active set of current vertices.
 Unlike away-step, it transfers weight from an away vertex to another vertex of the active set.
+
+$COMMON_ARGS
+
+$COMMON_KWARGS
+
+$RETURN_ACTIVESET
 """
 function blended_pairwise_conditional_gradient(
     f,

--- a/src/block_coordinate_algorithms.jl
+++ b/src/block_coordinate_algorithms.jl
@@ -453,12 +453,21 @@ function update_iterate(
 end
 
 """
-    block_coordinate_frank_wolfe(f, grad!, lmo::ProductLMO{N}, x0; ...) where {N}
+    block_coordinate_frank_wolfe(f, grad!, lmo::ProductLMO{N}, x0; kwargs...) where {N}
 
 Block-coordinate version of the Frank-Wolfe algorithm.
 Minimizes objective `f` over the product of feasible domains specified by the `lmo`.
 The optional argument the `update_order` is of type [`FrankWolfe.BlockCoordinateUpdateOrder`](@ref) and controls the order in which the blocks are updated.
 The argument `update_step` is a single instance or tuple of [`FrankWolfe.UpdateStep`](@ref) and defines which FW-algorithms to use to update the iterates in the different blocks.
+
+See [S. Lacoste-Julien, M. Jaggi, M. Schmidt, and P. Pletscher 2013](https://arxiv.org/abs/1207.4747)
+and [A. Beck, E. Pauwels and S. Sabach 2015](https://arxiv.org/abs/1502.03716) for more details about Block-Coordinate Frank-Wolfe.
+
+$COMMON_ARGS
+
+$COMMON_KWARGS
+
+# Return
 
 The method returns a tuple `(x, v, primal, dual_gap, traj_data)` with:
 - `x` cartesian product of final iterates
@@ -466,9 +475,6 @@ The method returns a tuple `(x, v, primal, dual_gap, traj_data)` with:
 - `primal` primal value `f(x)`
 - `dual_gap` final Frank-Wolfe gap
 - `traj_data` vector of trajectory information.
-
-See [S. Lacoste-Julien, M. Jaggi, M. Schmidt, and P. Pletscher 2013](https://arxiv.org/abs/1207.4747)
-and [A. Beck, E. Pauwels and S. Sabach 2015](https://arxiv.org/abs/1502.03716) for more details about Block-Coordinate Frank-Wolfe.
 """
 function block_coordinate_frank_wolfe(
     f,

--- a/src/corrective_frankwolfe.jl
+++ b/src/corrective_frankwolfe.jl
@@ -6,6 +6,10 @@ A corrective Frank-Wolfe variant with corrective step defined by `corrective_ste
 
 A corrective FW algorithm alternates between a standard FW step at which a vertex is added to the active set and a corrective step at which an update is performed in the convex hull of current vertices.
 Examples of corrective FW algorithms include blended (pairwise) conditional gradients, away-step Frank-Wolfe, and fully-corrective Frank-Wolfe.
+
+$COMMON_KWARGS
+
+$RETURN_ACTIVESET
 """
 function corrective_frank_wolfe(
     f,

--- a/src/defs.jl
+++ b/src/defs.jl
@@ -1,13 +1,29 @@
 
 
 """
+    MemoryEmphasis
+
 Emphasis given to the algorithm for memory-saving or not.
-The default memory-saving mode may be slower than
-OutplaceEmphasis mode for small dimensions.
+
+Concrete subtypes:
+
+- [`InplaceMemoryEmphasis`](@ref) (the default, meant to save memory)
+- [`OutplaceMemoryEmphasis`](@ref) (may be faster for small dimensions)
 """
 abstract type MemoryEmphasis end
 
+"""
+    InplaceEmphasis
+
+In-place version of [`MemoryEmphasis`](@ref).
+"""
 struct InplaceEmphasis <: MemoryEmphasis end
+
+"""
+    OutplaceEmphasis
+
+Out-of-place version of [`MemoryEmphasis`](@ref).
+"""
 struct OutplaceEmphasis <: MemoryEmphasis end
 
 @enum StepType begin
@@ -39,7 +55,26 @@ const steptype_string = (
 )
 
 """
+    CallbackState
+
 Main structure created before and passed to the callback in first position.
+
+# Fields
+
+- `t`
+- `primal`
+- `dual`
+- `dual_gap`
+- `time`
+- `x`
+- `v`
+- `d`
+- `gamma`
+- `f`
+- `grad!`
+- `lmo`
+- `gradient`
+- `step_type`
 """
 struct CallbackState{TP,TDV,TDG,XT,VT,DT,TG,FT,GFT,LMO,GT}
     t::Int
@@ -58,6 +93,11 @@ struct CallbackState{TP,TDV,TDG,XT,VT,DT,TG,FT,GFT,LMO,GT}
     step_type::StepType
 end
 
+"""
+    callback_state(state::CallbackState)
+
+Select a subset of fields from [`CallbackState`](@ref) to include in the trajectory: `(t, primal, dual, dual_gap, time)`.
+"""
 function callback_state(state::CallbackState)
     return (state.t, state.primal, state.dual, state.dual_gap, state.time)
 end

--- a/src/dicg.jl
+++ b/src/dicg.jl
@@ -33,6 +33,12 @@ dicg_maximum_step(lmo, direction, x)
 Implements the Decomposition-Invariant Conditional Gradient from:
 Garber, Ofer (2016), Linear-memory and decomposition-invariant linearly convergent conditional gradient algorithm for structured polytopes.
 The algorithm performs pairwise steps with the away direction computed by calls to a modified linear oracle, see [`FrankWolfe.is_decomposition_invariant_oracle`](@ref) for the extended linear minimization oracle interface required.
+
+$COMMON_ARGS
+
+$COMMON_KWARGS
+
+$RETURN
 """
 function decomposition_invariant_conditional_gradient(
     f,
@@ -277,6 +283,12 @@ end
 
 Implements the Blended variant of the Decomposition-Invariant Conditional Gradient.
 The algorithm performs pairwise steps with the away direction computed by calls to a modified linear oracle, see [`FrankWolfe.is_decomposition_invariant_oracle`](@ref) for the extended linear minimization oracle interface required.
+
+$COMMON_ARGS
+
+$COMMON_KWARGS
+
+$RETURN
 """
 function blended_decomposition_invariant_conditional_gradient(
     f,

--- a/src/docstrings.jl
+++ b/src/docstrings.jl
@@ -1,0 +1,52 @@
+# Common parts of algorithm docstrings, to be interpolated in each
+
+const RETURN = """
+# Return
+
+Returns a tuple `(x, v, primal, dual_gap, traj_data)` with:
+- `x`: the final iterate
+- `v`: the last vertex from the linear minimization oracle
+- `primal`: the final primal value `f(x)`
+- `dual_gap`: the final Frank-Wolfe gap
+- `traj_data`: a vector of trajectory information, each element being the output of [`callback_state`](@ref).
+"""
+
+const RETURN_ACTIVESET = replace(RETURN, "traj_data)" => "traj_data, active_set)") * """
+- `active_set`: the computed active set of vertices, of which the solution is a convex combination
+"""
+
+const COMMON_ARGS = """
+# Common arguments
+
+These positional arguments are common to most Frank-Wolfe variants:
+
+- `f`: a function `f(x)` computing the value of the objective to minimize at point `x`
+- `grad!`: a function `grad!(g, x)` overwriting `g` with the gradient of `f` at point `x`
+- `lmo`: a linear minimization oracle, subtyping [`LinearMinimizationOracle`](@ref)
+- `x0`: a starting point for the optimization
+"""
+
+const COMMON_KWARGS = """
+# Common keyword arguments
+
+These keyword arguments are common to most Frank-Wolfe variants.
+
+!!! warning
+    The current variant may have additional keyword arguments, documented elsewhere, or it may only use a subset of the ones listed below.
+    The default values of these arguments may also vary between variants, and thus are not part of the public API.
+
+- `line_search::LineSearchMethod`: an object specifying the line search and its parameters (see [`LineSearchMethod`](@ref))
+- `momentum::Union{Real,Nothing}=nothing`: constant momentum to apply to the gradient
+- `epsilon::Real`: absolute dual gap threshold at which the algorithm is interrupted
+- `max_iteration::Integer`: maximum number of iterations after which the algorithm is interrupted
+- `print_iter::Integer`: interval between two consecutive log prints, expressed in number of iterations
+- `trajectory::Bool=false`: whether to record the trajectory of algorithm states (through callbacks)
+- `verbose::Bool`: whether to print periodic logs (through callbacks)
+- `memory_mode::MemoryEmphasis`: an object dictating whether the algorithm operates in-place or out-of-place (see [`MemoryEmphasis`](@ref))
+- `gradient=nothing`: pre-allocated container for the gradient
+- `callback=nothing`: function called on a [`CallbackState`](@ref) at each iteration
+- `traj_data=[]`: pre-allocated storage for the trajectory of algorithm states
+- `timeout::Real=Inf`: maximum time after which the algorithm is interrupted (in nanoseconds)
+- `linesearch_workspace=nothing`: pre-allocated workspace for the line search 
+- `dual_gap_compute_frequency::Integer=1`: frequency of dual gap computation, 
+"""

--- a/src/fw_algorithms.jl
+++ b/src/fw_algorithms.jl
@@ -1,14 +1,14 @@
 
 """
-    frank_wolfe(f, grad!, lmo, x0; ...)
+    frank_wolfe(f, grad!, lmo, x0; kwargs...)
 
 Simplest form of the Frank-Wolfe algorithm.
-Returns a tuple `(x, v, primal, dual_gap, traj_data)` with:
-- `x` final iterate
-- `v` last vertex from the LMO
-- `primal` primal value `f(x)`
-- `dual_gap` final Frank-Wolfe gap
-- `traj_data` vector of trajectory information.
+
+$COMMON_ARGS
+
+$COMMON_KWARGS
+
+$RETURN
 """
 function frank_wolfe(
     f,
@@ -242,12 +242,18 @@ end
 
 
 """
-    lazified_conditional_gradient(f, grad!, lmo_base, x0; ...)
+    lazified_conditional_gradient(f, grad!, lmo_base, x0; kwargs...)
 
 Similar to [`FrankWolfe.frank_wolfe`](@ref) but lazyfying the LMO:
 each call is stored in a cache, which is looked up first for a good-enough direction.
 The cache used is a [`FrankWolfe.MultiCacheLMO`](@ref) or a [`FrankWolfe.VectorCacheLMO`](@ref)
 depending on whether the provided `cache_size` option is finite.
+
+$COMMON_ARGS
+
+$COMMON_KWARGS
+
+$RETURN
 """
 function lazified_conditional_gradient(
     f,
@@ -475,10 +481,16 @@ function lazified_conditional_gradient(
 end
 
 """
-    stochastic_frank_wolfe(f::StochasticObjective, lmo, x0; ...)
+    stochastic_frank_wolfe(f::StochasticObjective, lmo, x0; kwargs...)
 
 Stochastic version of Frank-Wolfe, evaluates the objective and gradient stochastically,
 implemented through the [`FrankWolfe.StochasticObjective`](@ref) interface.
+
+$COMMON_ARGS
+
+$COMMON_KWARGS
+
+# Specific keyword arguments
 
 Keyword arguments include `batch_size` to pass a fixed `batch_size`
 or a `batch_iterator` implementing
@@ -487,6 +499,8 @@ Variance-reduced and projection-free stochastic optimization, E Hazan, H Luo, 20
 
 Similarly, a constant `momentum` can be passed or replaced by a `momentum_iterator`
 implementing `momentum = FrankWolfe.momentum_iterate(momentum_iterator)`.
+
+$RETURN
 """
 function stochastic_frank_wolfe(
     f::StochasticObjective,

--- a/src/linesearch.jl
+++ b/src/linesearch.jl
@@ -1,5 +1,7 @@
 
 """
+    LineSearchMethod
+
 Line search method to apply once the direction is computed.
 A `LineSearchMethod` must implement
 ```

--- a/src/pairwise.jl
+++ b/src/pairwise.jl
@@ -1,12 +1,18 @@
 
 """
-    pairwise_frank_wolfe(f, grad!, lmo, x0; ...)
+    pairwise_frank_wolfe(f, grad!, lmo, x0; kwargs...)
 
 Frank-Wolfe with pairwise steps.
 The algorithm maintains the current iterate as a convex combination of vertices in the
 [`FrankWolfe.ActiveSet`](@ref) data structure.
 See [M. Besançon, A. Carderera and S. Pokutta 2021](https://arxiv.org/abs/2104.06675) for illustrations of away steps. 
 Unlike away-step, it transfers weight from an away vertex to another vertex.
+
+$COMMON_ARGS
+
+$COMMON_KWARGS
+
+$RETURN_ACTIVESET
 """
 function pairwise_frank_wolfe(
     f,


### PR DESCRIPTION
Fixes #331 

Some caveats:

- Documenting this precisely would significantly widen the public API that you're not allowed to break. I added a warning in that direction but you may want to strengthen it.
- I'm not sure about my interpretation of all keyword arguments, please double-check.
- I have only documented the algorithms that looked most like the basic `frank_wolfe`, others have signtatures that seemed too different to me.