### PR TITLE
Added convex hull matrix LMO

### DIFF
--- a/src/polytope_oracles.jl
+++ b/src/polytope_oracles.jl
@@ -341,6 +341,43 @@ function compute_extreme_point(lmo::ConvexHullLMO{AT}, direction; v=nothing, kwa
 end
 
 """
+    ConvexHullMatrixLMO{AT,VT}
+
+Convex hull of a finite number of vertices stored in a matrix of type `MT`.
+Each column represents one vertex.
+The buffer stores the result of the matrix-vector multiplication of each column with the direction.
+The column minimizing that inner product is returned as a view.
+"""
+struct ConvexHullMatrixLMO{MT<:AbstractMatrix,BT<:AbstractVector} <: LinearMinimizationOracle
+    vertex_matrix::MT
+    buffer::BT
+end
+
+function ConvexHullMatrixLMO(vertex_matrix::AbstractMatrix{MT}) where {MT}
+    return ConvexHullMatrixLMO(
+        vertex_matrix,
+        collect(similar(vertex_matrix, float(MT), size(vertex_matrix, 2))),
+    )
+end
+
+function ConvexHullMatrixLMO(vertices::AbstractVector{AT}) where {AT<:AbstractVector}
+    vertex_matrix = similar(vertices[1], length(vertices[1]), length(vertices))
+    for idx in eachindex(vertices)
+        @view(vertex_matrix[:, idx]) .= vertices[idx]
+    end
+    buffer = collect(similar(vertices[1], float(eltype(AT)), length(vertices)))
+    return ConvexHullMatrixLMO(vertex_matrix, buffer)
+end
+
+ConvexHullMatrixLMO(lmo::ConvexHullLMO) = ConvexHullMatrixLMO(lmo.vertices)
+
+function compute_extreme_point(lmo::ConvexHullMatrixLMO, direction; v=nothing, kwargs...)
+    mul!(lmo.buffer, lmo.vertex_matrix', direction)
+    idx = argmin(lmo.buffer)
+    return @view(lmo.vertex_matrix[:, idx])
+end
+
+"""
     ZeroOneHypercubeLMO
 
 {0,1} hypercube polytope.
@@ -362,7 +399,7 @@ end
 
 is_decomposition_invariant_oracle(::ZeroOneHypercubeLMO) = true
 
-function is_inface_feasible(ZeroOneHypercubeLMO, a, x)
+function is_inface_feasible(::ZeroOneHypercubeLMO, a, x)
     for idx in eachindex(a)
         if (x[idx] == 0 && a[idx] != 0) || (x[idx] == 1 && a[idx] != 1)
             return false

--- a/src/types.jl
+++ b/src/types.jl
@@ -86,6 +86,7 @@ Base.:-(x::ScaledHotVector, y::AbstractVector) = +(x, -y)
 Base.:-(x::ScaledHotVector, y::ScaledHotVector) = +(x, -y)
 
 Base.similar(v::ScaledHotVector{T}) where {T} = spzeros(T, length(v))
+Base.similar(::ScaledHotVector, ::Type{T}, dims::NTuple{N,Int}) where {T,N} = spzeros(T, dims)
 
 function Base.convert(::Type{Vector{T}}, v::ScaledHotVector) where {T}
     vc = zeros(T, v.len)

--- a/test/lmo.jl
+++ b/test/lmo.jl
@@ -835,7 +835,7 @@ end
     # test on unit vectors for sparse conversion
     vertices = [FrankWolfe.ScaledHotVector(1.0, 3, 5), FrankWolfe.ScaledHotVector(1.0, 2, 5)]
     lmo_sparse = FrankWolfe.ConvexHullMatrixLMO(vertices)
-    @test lmo_sparse.vertex_matrix isa SparseMatrixCSC
+    @test lmo_sparse.vertex_matrix isa SparseArrays.SparseMatrixCSC
     @test size(lmo_sparse.vertex_matrix) == (5, 2)
     v1 = FrankWolfe.compute_extreme_point(lmo_sparse, [0, -1, 0, 0, 0])
     @test v1 == vertices[2]

--- a/test/lmo.jl
+++ b/test/lmo.jl
@@ -811,6 +811,36 @@ end
     @test v == lmo.vertices[1]
 end
 
+@testset "Convex hull matrix" begin
+    vertices = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
+    lmo_list = FrankWolfe.ConvexHullLMO(vertices)
+    lmo_mat = FrankWolfe.ConvexHullMatrixLMO(hcat(vertices...))
+    # Results should match ConvexHullLMO for random directions
+    for _ in 1:100
+        d = randn(rng, 3)
+        v_list = FrankWolfe.compute_extreme_point(lmo_list, d)
+        v_mat = FrankWolfe.compute_extreme_point(lmo_mat, d)
+        @test v_list == v_mat
+    end
+    # Constructor from ConvexHullLMO should give equivalent results
+    lmo_from_list = FrankWolfe.ConvexHullMatrixLMO(lmo_list)
+    @test lmo_from_list.vertex_matrix == lmo_mat.vertex_matrix
+    # Matches ProbabilitySimplexLMO on the standard simplex vertices
+    for _ in 1:100
+        d = randn(rng, 3)
+        v_mat = FrankWolfe.compute_extreme_point(lmo_mat, d)
+        v_simplex = FrankWolfe.compute_extreme_point(FrankWolfe.ProbabilitySimplexLMO(1), d)
+        @test v_mat == v_simplex
+    end
+    # test on unit vectors for sparse conversion
+    vertices = [FrankWolfe.ScaledHotVector(1.0, 3, 5), FrankWolfe.ScaledHotVector(1.0, 2, 5)]
+    lmo_sparse = FrankWolfe.ConvexHullMatrixLMO(vertices)
+    @test lmo_sparse.vertex_matrix isa SparseMatrixCSC
+    @test size(lmo_sparse.vertex_matrix) == (5, 2)
+    v1 = FrankWolfe.compute_extreme_point(lmo_sparse, [0, -1, 0, 0, 0])
+    @test v1 == vertices[2]
+end
+
 @testset "Symmetric LMO" begin
     # See examples/reynolds.jl
     struct BellCorrelationsLMO{T} <: FrankWolfe.LinearMinimizationOracle


### PR DESCRIPTION
Some micro-benchmarks:
```julia
julia> @benchmark run_one(lmolist, 300)
BenchmarkTools.Trial: 365 samples with 1 evaluation per sample.
 Range (min … max):  10.543 ms … 21.530 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     13.699 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   13.675 ms ±  1.397 ms  ┊ GC (mean ± σ):  0.00% ± 0.00%

            ▃▂ ▃    ▃▆ ▃▅ ▃▃▂▅▇▆▄▃▄▃   █                       
  ▃▄▃▃▁▄▃▁▁▄████▇▇▆███▇█████████████▇█▇█▅▅▇▅▅▇▄▁▃▄▄▃▃▆▃▃▁▄▁▁▃ ▄
  10.5 ms         Histogram: frequency by time        17.3 ms <

 Memory estimate: 2.45 KiB, allocs estimate: 3.

julia> @benchmark run_one(lmomat, 300)
BenchmarkTools.Trial: 515 samples with 1 evaluation per sample.
 Range (min … max):  5.491 ms … 14.860 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     9.623 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   9.682 ms ±  1.771 ms  ┊ GC (mean ± σ):  0.00% ± 0.00%

                   ▃▅▆▃▃  █▄▁▄▃▅▂▄   ▃▁                       
  ▃▁▃▄▆▄▄▄▃▄▅▇▆▅▅█▇█████▇██████████████▇██▅▆▆▄▆▄▄▅▆▄▅▃▁▁▁▃▃▄ ▅
  5.49 ms        Histogram: frequency by time        14.3 ms <

 Memory estimate: 2.45 KiB, allocs estimate: 3.
```

slightly faster with vertices of size 300 and 10k of them