### PR TITLE
Decide active-set membership from the minimum the step already holds

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -1,5 +1,6 @@
 # Noteworthy changes in v0.6
 
+- The internal function `lp_separation_oracle` now returns a third element: the position of the returned atom in the active set, -1 when it is not an active atom, `nothing` when the active set was skipped [PR649](https://github.com/ZIB-IOL/FrankWolfe.jl/pull/649).
 - The function `FrankWolfe.update_iterate` was renamed to `FrankWolfe.update_block_iterate` to be more specific about it belonging to the block coordinate interface and avoid confusion.
 - A `status` field was added to the named tuple return of all algorithms, corresponding to a `FrankWolfe.ExecutionStatus` enum value indicating why the algorithm stopped.
 - The internal function `fast_dot(a, b)` was removed, now that the fast implementation of sparse dot products was added to `SparseArrays`. The quadratic form `fast_dot(a, Q, b)` still exists.

--- a/src/active_set.jl
+++ b/src/active_set.jl
@@ -329,8 +329,8 @@ Position of `atom` in `active_set`, or -1, decided from values the step
 already holds: `best_value` is the minimum of `dot(a, direction)` over the
 active atoms `a` and `best_index` its position, as `active_set_argminmax`
 returns them. If `atom` were active, `dot(atom, direction)` would be one of
-the values just minimised, so a strictly smaller value proves it absent
-without comparing a single atom. Otherwise the best atom is compared first:
+the values just minimised, so a strictly smaller value proves it absent.
+Otherwise the best atom is compared first:
 a vertex returned by the LMO cannot score above the minimum, so equality is
 a tie, and the tie is almost surely with the best atom itself. Only a tie
 with a different atom, which has probability zero for a real-valued

--- a/src/active_set.jl
+++ b/src/active_set.jl
@@ -323,6 +323,38 @@ function find_atom(active_set::AbstractActiveSet, atom)
 end
 
 """
+    find_atom(active_set, atom, direction, best_index, best_value)
+
+Position of `atom` in `active_set`, or -1, decided from values the step
+already holds: `best_value` is the minimum of `dot(a, direction)` over the
+active atoms `a` and `best_index` its position, as `active_set_argminmax`
+returns them. If `atom` were active, `dot(atom, direction)` would be one of
+the values just minimised, so a strictly smaller value proves it absent
+without comparing a single atom. Otherwise the best atom is compared first:
+a vertex returned by the LMO cannot score above the minimum, so equality is
+a tie, and the tie is almost surely with the best atom itself. Only a tie
+with a different atom, which has probability zero for a real-valued
+direction, falls back to the scan. Passing `best_index = -1` with
+`best_value = -Inf` (a minimum that is no longer valid) also falls back.
+
+Enabled for `ActiveSet`, whose `active_set_argminmax` computes exactly
+`dot(a, direction)`; other active set types keep the scan until their own
+minimum is known to be the same function of the same inputs.
+"""
+function find_atom(active_set::ActiveSet, atom, direction, best_index::Integer, best_value)
+    if dot(atom, direction) < best_value
+        return -1
+    end
+    if best_index > 0 && _unsafe_equal(active_set.atoms[best_index], atom)
+        return Int(best_index)
+    end
+    return find_atom(active_set, atom)
+end
+
+find_atom(active_set::AbstractActiveSet, atom, direction, best_index::Integer, best_value) =
+    find_atom(active_set, atom)
+
+"""
     active_set_argmin(active_set::AbstractActiveSet, direction)
 
 Computes the linear minimizer in the direction on the active set.

--- a/src/active_set.jl
+++ b/src/active_set.jl
@@ -325,24 +325,22 @@ end
 """
     find_atom(active_set, atom, direction, best_index, best_value)
 
-Position of `atom` in `active_set`, or -1, decided from values the step
-already holds: `best_value` is the minimum of `dot(a, direction)` over the
-active atoms `a` and `best_index` its position, as `active_set_argminmax`
-returns them. If `atom` were active, `dot(atom, direction)` would be one of
-the values just minimised, so a strictly smaller value proves it absent.
-Otherwise the best atom is compared first:
-a vertex returned by the LMO cannot score above the minimum, so equality is
-a tie, and the tie is almost surely with the best atom itself. Only a tie
-with a different atom, which has probability zero for a real-valued
-direction, falls back to the scan. Passing `best_index = -1` with
-`best_value = -Inf` (a minimum that is no longer valid) also falls back.
+Position of `atom` in `active_set`, or -1 if it is not present. `best_index`
+and `best_value` are the position and value of the minimum of
+`dot(a, direction)` over the active atoms, as returned by
+[`active_set_argminmax`](@ref) with the same `direction`. Compares `atom`
+against `active_set.atoms[best_index]` first, certifies it absent when
+`dot(atom, direction) < best_value`, and scans otherwise. Pass
+`best_index = -1` and `best_value = -Inf` when no valid minimum is
+available. Active set types other than `ActiveSet` always scan: their
+`active_set_argminmax` may return a minimum that is not `dot(a, direction)`.
 """
 function find_atom(active_set::ActiveSet, atom, direction, best_index::Integer, best_value)
-    if dot(atom, direction) < best_value
-        return -1
-    end
     if best_index > 0 && _unsafe_equal(active_set.atoms[best_index], atom)
         return Int(best_index)
+    end
+    if dot(atom, direction) < best_value
+        return -1
     end
     return find_atom(active_set, atom)
 end

--- a/src/active_set.jl
+++ b/src/active_set.jl
@@ -336,10 +336,6 @@ a tie, and the tie is almost surely with the best atom itself. Only a tie
 with a different atom, which has probability zero for a real-valued
 direction, falls back to the scan. Passing `best_index = -1` with
 `best_value = -Inf` (a minimum that is no longer valid) also falls back.
-
-Enabled for `ActiveSet`, whose `active_set_argminmax` computes exactly
-`dot(a, direction)`; other active set types keep the scan until their own
-minimum is known to be the same function of the same inputs.
 """
 function find_atom(active_set::ActiveSet, atom, direction, best_index::Integer, best_value)
     if dot(atom, direction) < best_value

--- a/src/blended_cg.jl
+++ b/src/blended_cg.jl
@@ -1132,9 +1132,11 @@ function simplex_gradient_descent_over_convex_hull(
 end
 
 """
-Returns either a tuple `(y, val)` with `y` an atom from the active set satisfying
-the progress criterion and `val` the corresponding gap `dot(y, direction)`
-or the same tuple with `y` from the LMO.
+Returns a tuple `(y, val, idx)` with `y` an atom from the active set satisfying
+the progress criterion and `val` the corresponding gap `dot(y, direction)`,
+or the same tuple with `y` from the LMO. `idx` is the position of `y` in the
+active set, -1 if `y` is not an active atom, and `nothing` when the active
+set was skipped (`force_fw_step = true`).
 
 `inplace_loop` controls whether the iterate type allows in-place writes.
 `kwargs` are passed on to the LMO oracle.
@@ -1201,11 +1203,7 @@ function lp_separation_oracle(
     else
         y = compute_extreme_point(lmo, direction; kwargs...)
     end
-    # don't return nothing but y, dot(direction, y) / use y for step outside / and update phi_value as in LCG (lines 402 - 406)
     val = dot(direction, y)
-    # the position of y in the active set, decided from the scan above when
-    # there was one: below its minimum means absent, a tie is almost surely
-    # with the best atom, and only a tie with another atom searches the set
     idx = if force_fw_step
         nothing
     elseif _unsafe_equal(ybest, y)

--- a/src/blended_cg.jl
+++ b/src/blended_cg.jl
@@ -265,7 +265,7 @@ function blended_conditional_gradient(
         primal = f(x)
         grad!(gradient, x)
         # compute new atom
-        (v, value) = lp_separation_oracle(
+        (v, value, v_index) = lp_separation_oracle(
             lmo,
             active_set,
             gradient,
@@ -359,6 +359,8 @@ function blended_conditional_gradient(
                     active_set,
                     gamma,
                     v,
+                    true,
+                    v_index,
                     add_dropped_vertices=use_extra_vertex_storage,
                     vertex_storage=extra_vertex_storage,
                 )
@@ -1153,6 +1155,7 @@ function lp_separation_oracle(
     # if FW step forced, ignore active set
     if !force_fw_step
         ybest = active_set.atoms[1]
+        idx_best = 1
         x = active_set.weights[1] * active_set.atoms[1]
         if inplace_loop
             if !isa(x, Union{Array,SparseArrays.AbstractSparseArray})
@@ -1175,11 +1178,12 @@ function lp_separation_oracle(
             if val < val_best
                 val_best = val
                 ybest = y
+                idx_best = idx
             end
         end
         xval = dot(direction, x)
         if xval - val_best ≥ min_gap / sparsity_control
-            return (ybest, val_best)
+            return (ybest, val_best, idx_best)
         end
     end
     # optionally: try vertex storage
@@ -1198,5 +1202,18 @@ function lp_separation_oracle(
         y = compute_extreme_point(lmo, direction; kwargs...)
     end
     # don't return nothing but y, dot(direction, y) / use y for step outside / and update phi_value as in LCG (lines 402 - 406)
-    return (y, dot(direction, y))
+    val = dot(direction, y)
+    # the position of y in the active set, decided from the scan above when
+    # there was one: below its minimum means absent, a tie is almost surely
+    # with the best atom, and only a tie with another atom searches the set
+    idx = if force_fw_step
+        nothing
+    elseif val < val_best
+        -1
+    elseif _unsafe_equal(ybest, y)
+        idx_best
+    else
+        find_atom(active_set, y)
+    end
+    return (y, val, idx)
 end

--- a/src/blended_cg.jl
+++ b/src/blended_cg.jl
@@ -1208,10 +1208,10 @@ function lp_separation_oracle(
     # with the best atom, and only a tie with another atom searches the set
     idx = if force_fw_step
         nothing
-    elseif val < val_best
-        -1
     elseif _unsafe_equal(ybest, y)
         idx_best
+    elseif val < val_best
+        -1
     else
         find_atom(active_set, y)
     end

--- a/src/blended_pairwise.jl
+++ b/src/blended_pairwise.jl
@@ -208,7 +208,7 @@ function blended_pairwise_conditional_gradient(
             grad!(gradient, x)
         end
 
-        _, v_local, v_local_loc, _, a_lambda, a, a_loc, _, _ =
+        _, v_local, v_local_loc, v_local_value, a_lambda, a, a_loc, _, _ =
             active_set_argminmax(active_set, gradient)
 
         dot_forward_vertex = dot(gradient, v_local)
@@ -311,6 +311,9 @@ function blended_pairwise_conditional_gradient(
                 x = get_active_set_iterate(active_set)
                 grad!(gradient, x)
                 dual_gap = dot(gradient, x) - dot(gradient, v)
+                # the active set and the gradient changed: the minimum found
+                # above no longer says anything about the membership of v
+                v_local_loc, v_local_value = -1, typemin(typeof(v_local_value))
             end
             # Note: In the following, we differentiate between lazy and non-lazy updates.
             # The reason is that only the lazy version depends on the phi_value.
@@ -371,7 +374,11 @@ function blended_pairwise_conditional_gradient(
                     active_set_initialize!(active_set, v)
                 else
                     renorm = mod(t, renorm_interval) == 0
-                    active_set_update!(active_set, gamma, v, renorm, nothing)
+                    # v is not active whenever it scores below the active set's
+                    # own minimum, which is the case in this branch in exact
+                    # arithmetic; the comparison replaces the scan of the set
+                    v_index = find_atom(active_set, v, gradient, v_local_loc, v_local_value)
+                    active_set_update!(active_set, gamma, v, renorm, v_index)
                 end
             else # dual step
                 # we only update the dual gap if the step was regular (not lazy from discarded set)

--- a/src/blended_pairwise.jl
+++ b/src/blended_pairwise.jl
@@ -311,8 +311,7 @@ function blended_pairwise_conditional_gradient(
                 x = get_active_set_iterate(active_set)
                 grad!(gradient, x)
                 dual_gap = dot(gradient, x) - dot(gradient, v)
-                # the active set and the gradient changed: the minimum found
-                # above no longer says anything about the membership of v
+                # the cleanup and the recomputed gradient invalidate the minimum found above
                 v_local_loc, v_local_value = -1, typemin(typeof(v_local_value))
             end
             # Note: In the following, we differentiate between lazy and non-lazy updates.
@@ -374,9 +373,6 @@ function blended_pairwise_conditional_gradient(
                     active_set_initialize!(active_set, v)
                 else
                     renorm = mod(t, renorm_interval) == 0
-                    # v is not active whenever it scores below the active set's
-                    # own minimum, which is the case in this branch in exact
-                    # arithmetic; the comparison replaces the scan of the set
                     v_index = find_atom(active_set, v, gradient, v_local_loc, v_local_value)
                     active_set_update!(active_set, gamma, v, renorm, v_index)
                 end

--- a/src/block_coordinate_algorithms.jl
+++ b/src/block_coordinate_algorithms.jl
@@ -394,8 +394,7 @@ function update_block_iterate(
             x = get_active_set_iterate(s.active_set)
             grad!(gradient, x)
             dual_gap = dot(gradient, x) - dot(gradient, v)
-            # the active set and the gradient changed: the minimum found
-            # above no longer says anything about the membership of v
+            # the cleanup and the recomputed gradient invalidate the minimum found above
             v_local_loc, v_local_value = -1, typemin(typeof(v_local_value))
         end
 

--- a/src/block_coordinate_algorithms.jl
+++ b/src/block_coordinate_algorithms.jl
@@ -334,7 +334,7 @@ function update_block_iterate(
 
     step_type = ST_REGULAR
 
-    _, v_local, v_local_loc, _, a_lambda, a, a_loc, _, _ =
+    _, v_local, v_local_loc, v_local_value, a_lambda, a, a_loc, _, _ =
         active_set_argminmax(s.active_set, gradient)
 
     dot_forward_vertex = dot(gradient, v_local)
@@ -394,6 +394,9 @@ function update_block_iterate(
             x = get_active_set_iterate(s.active_set)
             grad!(gradient, x)
             dual_gap = dot(gradient, x) - dot(gradient, v)
+            # the active set and the gradient changed: the minimum found
+            # above no longer says anything about the membership of v
+            v_local_loc, v_local_value = -1, typemin(typeof(v_local_value))
         end
 
         if !s.lazy || dual_gap ≥ s.phi_value / s.sparsity_control
@@ -418,7 +421,8 @@ function update_block_iterate(
                 active_set_initialize!(s.active_set, v)
             else
                 renorm = mod(t, s.renorm_interval) == 0
-                active_set_update!(s.active_set, gamma, v, renorm, nothing)
+                v_index = find_atom(s.active_set, v, gradient, v_local_loc, v_local_value)
+                active_set_update!(s.active_set, gamma, v, renorm, v_index)
             end
         else # dual step
             if step_type != ST_LAZYSTORAGE

--- a/src/pairwise.jl
+++ b/src/pairwise.jl
@@ -418,7 +418,7 @@ function lazy_pfw_step(
     sparsity_control=2.0,
     memory_mode::MemoryEmphasis=InplaceEmphasis(),
 )
-    _, v_local, v_local_loc, _, a_lambda, a_local, a_local_loc, _, _ =
+    _, v_local, v_local_loc, v_local_value, a_lambda, a_local, a_local_loc, _, _ =
         active_set_argminmax(active_set, gradient)
     # We will always have an away vertex determining the steplength. 
     gamma_max = a_lambda
@@ -455,6 +455,8 @@ function lazy_pfw_step(
             step_type = ST_PAIRWISE
         end
 
+        # decided from the minimum computed above, without scanning the active set
+        fw_index = find_atom(active_set, v, gradient, v_local_loc, v_local_value)
         # Real dual gap promises enough progress.
         grad_dot_fw_vertex = dot(gradient, v)
         dual_gap = grad_dot_x - grad_dot_fw_vertex
@@ -480,7 +482,8 @@ function pfw_step(
     memory_mode::MemoryEmphasis=InplaceEmphasis(),
 )
     step_type = ST_PAIRWISE
-    _, _, _, _, a_lambda, a_local, a_local_loc = active_set_argminmax(active_set, gradient)
+    _, _, v_local_loc, v_local_value, a_lambda, a_local, a_local_loc =
+        active_set_argminmax(active_set, gradient)
     away_vertex = a_local
     away_index = a_local_loc
     # We will always have a away vertex determining the steplength. 
@@ -488,7 +491,8 @@ function pfw_step(
 
     v = compute_extreme_point(lmo, gradient)
     fw_vertex = v
-    fw_index = nothing
+    # decided from the minimum computed above, without scanning the active set
+    fw_index = find_atom(active_set, v, gradient, v_local_loc, v_local_value)
     grad_dot_x = dot(gradient, x)
     dual_gap = grad_dot_x - dot(gradient, v)
     d = muladd_memory_mode(memory_mode, d, a_local, v)

--- a/src/pairwise.jl
+++ b/src/pairwise.jl
@@ -455,7 +455,6 @@ function lazy_pfw_step(
             step_type = ST_PAIRWISE
         end
 
-        # decided from the minimum computed above, without scanning the active set
         fw_index = find_atom(active_set, v, gradient, v_local_loc, v_local_value)
         # Real dual gap promises enough progress.
         grad_dot_fw_vertex = dot(gradient, v)
@@ -491,7 +490,6 @@ function pfw_step(
 
     v = compute_extreme_point(lmo, gradient)
     fw_vertex = v
-    # decided from the minimum computed above, without scanning the active set
     fw_index = find_atom(active_set, v, gradient, v_local_loc, v_local_value)
     grad_dot_x = dot(gradient, x)
     dual_gap = grad_dot_x - dot(gradient, v)

--- a/test/active_set.jl
+++ b/test/active_set.jl
@@ -202,12 +202,15 @@ end
     x = FrankWolfe.get_active_set_iterate(active_set)
     @test x ≈ [-0.4, -0.4]
     gradient_dir = ∇f(x)
-    (y, _) = FrankWolfe.lp_separation_oracle(lmo, active_set, gradient_dir, 0.5, 1)
+    (y, _, y_index) = FrankWolfe.lp_separation_oracle(lmo, active_set, gradient_dir, 0.5, 1)
     @test y ∈ active_set.atoms
-    (y2, _) =
+    # the oracle returns the position of the atom it took from the active set
+    @test active_set.atoms[y_index] == y
+    (y2, _, y2_index) =
         FrankWolfe.lp_separation_oracle(lmo, active_set, gradient_dir, 3 + dot(x, gradient_dir), 1)
-    # found new vertex not in active set
+    # found new vertex not in active set, and said so without a scan
     @test y2 ∉ active_set.atoms
+    @test y2_index == -1
 
     # Criterion too high, no satisfactory point
     (y3, _) = FrankWolfe.lp_separation_oracle(
@@ -257,6 +260,66 @@ end
 
     # ensure that ActiveSet is created correctly, tests a fix for a bug when x0 is a BigFloat
     @test length(FrankWolfe.ActiveSet([(1.0, x0)])) == 1
+end
+
+@testset "find_atom from the minimum a step already holds" begin
+    atoms = [rand(rng, 6) for _ in 1:25]
+    active_set = ActiveSet([(1 / 25, a) for a in atoms])
+    direction = randn(rng, 6)
+    _, v_local, v_local_loc, v_local_value, _, _, _, _, _ =
+        FrankWolfe.active_set_argminmax(active_set, direction)
+
+    # every active atom is found at its position, the best one without a scan
+    for (i, a) in enumerate(atoms)
+        @test FrankWolfe.find_atom(active_set, a, direction, v_local_loc, v_local_value) == i
+    end
+    @test FrankWolfe.find_atom(active_set, copy(v_local), direction, v_local_loc, v_local_value) ==
+          v_local_loc
+
+    # the LMO's vertex scores below the active set's minimum: certified absent
+    lmo = FrankWolfe.LpNormBallLMO{Inf}(1.0)
+    v = FrankWolfe.compute_extreme_point(lmo, direction)
+    @test dot(v, direction) < v_local_value
+    @test FrankWolfe.find_atom(active_set, v, direction, v_local_loc, v_local_value) == -1
+
+    # random queries, present or not, agree with the scan
+    for _ in 1:200
+        query = rand(rng, Bool) ? atoms[rand(rng, 1:25)] : rand(rng, 6)
+        @test FrankWolfe.find_atom(active_set, query, direction, v_local_loc, v_local_value) ==
+              FrankWolfe.find_atom(active_set, query)
+    end
+
+    # a tie with an atom other than the best one falls back to the scan:
+    # a zero direction makes every atom tie at zero
+    zero_direction = zeros(6)
+    @test FrankWolfe.find_atom(active_set, atoms[7], zero_direction, 1, 0.0) == 7
+    @test FrankWolfe.find_atom(active_set, rand(rng, 6), zero_direction, 1, 0.0) == -1
+
+    # a minimum that is no longer valid (index -1, value -Inf) also falls back
+    @test FrankWolfe.find_atom(active_set, atoms[3], direction, -1, -Inf) == 3
+    @test FrankWolfe.find_atom(active_set, rand(rng, 6), direction, -1, -Inf) == -1
+
+    # the update path uses it: no atom is ever stored twice, on sparse atoms too
+    n = 8
+    xp = rand(rng, n, n)
+    f(x) = dot(x - xp, x - xp)
+    function grad!(storage, x)
+        storage .= 2 .* (x .- xp)
+        return storage
+    end
+    birkhoff = FrankWolfe.BirkhoffPolytopeLMO()
+    x0 = FrankWolfe.compute_extreme_point(birkhoff, randn(rng, n, n))
+    for run in (
+        (f, g, l, x) -> FrankWolfe.pairwise_frank_wolfe(f, g, l, x; max_iteration=300, lazy=false),
+        (f, g, l, x) -> FrankWolfe.pairwise_frank_wolfe(f, g, l, x; max_iteration=300, lazy=true),
+        (f, g, l, x) ->
+            FrankWolfe.blended_pairwise_conditional_gradient(f, g, l, x; max_iteration=300),
+        (f, g, l, x) -> FrankWolfe.blended_conditional_gradient(f, g, l, x; max_iteration=300),
+    )
+        res = run(f, grad!, birkhoff, x0)
+        @test allunique(res.active_set.atoms)
+        @test FrankWolfe.active_set_validate(res.active_set)
+    end
 end
 
 end # module

--- a/test/active_set.jl
+++ b/test/active_set.jl
@@ -4,7 +4,7 @@ using Test
 
 using FrankWolfe
 import FrankWolfe: ActiveSet
-using LinearAlgebra: dot, norm
+using LinearAlgebra: dot, norm, I
 using Random
 using StableRNGs
 
@@ -213,13 +213,29 @@ end
     @test y2_index == -1
 
     # Criterion too high, no satisfactory point
-    (y3, _) = FrankWolfe.lp_separation_oracle(
+    (y3, _, y3_index) = FrankWolfe.lp_separation_oracle(
         lmo,
         active_set,
         gradient_dir,
         norm(gradient_dir)^2 + dot(x, gradient_dir),
         1,
     )
+    @test y3_index == FrankWolfe.find_atom(active_set, y3)
+
+    # the LMO's vertex is already active: the oracle reports its position
+    v_lmo = FrankWolfe.compute_extreme_point(lmo, gradient_dir)
+    active_set_with_v = ActiveSet([(0.5, [-1.0, -1.0]), (0.3, [0.0, 1.0]), (0.2, Vector(v_lmo))])
+    (y4, _, y4_index) =
+        FrankWolfe.lp_separation_oracle(lmo, active_set_with_v, gradient_dir, 1e6, 1)
+    @test y4_index == 3
+    @test active_set_with_v.atoms[y4_index] == y4
+
+    # a zero direction ties every atom and the LMO vertex is not the best atom:
+    # the oracle falls back to the scan and still reports the right position
+    active_set_reordered = ActiveSet([(0.3, [0.0, 1.0]), (0.5, [-1.0, -1.0]), (0.2, Vector(v_lmo))])
+    (y5, _, y5_index) = FrankWolfe.lp_separation_oracle(lmo, active_set_reordered, zeros(2), 1e6, 1)
+    @test y5_index == FrankWolfe.find_atom(active_set_reordered, y5)
+    @test y5_index == 2
 end
 
 @testset "Argminmax" begin
@@ -299,6 +315,15 @@ end
     @test FrankWolfe.find_atom(active_set, atoms[3], direction, -1, -Inf) == 3
     @test FrankWolfe.find_atom(active_set, rand(rng, 6), direction, -1, -Inf) == -1
 
+    # types without the certificate ignore the minimum arguments and scan
+    as_cached = FrankWolfe.ActiveSetQuadraticProductCaching(
+        [(1 / 25, a) for a in atoms],
+        Matrix{Float64}(I, 6, 6),
+        zeros(6),
+    )
+    @test FrankWolfe.find_atom(as_cached, atoms[7], direction, v_local_loc, Inf) == 7
+    @test FrankWolfe.find_atom(as_cached, rand(rng, 6), direction, v_local_loc, Inf) == -1
+
     # end-to-end on sparse atoms (Birkhoff): the update paths must never store an atom twice
     n = 8
     xp = rand(rng, n, n)
@@ -319,6 +344,8 @@ end
         res = run(f, grad!, birkhoff, x0)
         @test allunique(res.active_set.atoms)
         @test FrankWolfe.active_set_validate(res.active_set)
+        # weight landing on a wrong index would desynchronize x from the decomposition
+        @test res.active_set.x ≈ sum(λ .* a for (λ, a) in res.active_set)
     end
 
     # an atom stored in another representation must be found, never certified

--- a/test/active_set.jl
+++ b/test/active_set.jl
@@ -4,7 +4,7 @@ using Test
 
 using FrankWolfe
 import FrankWolfe: ActiveSet
-using LinearAlgebra: dot, norm, I
+using LinearAlgebra: dot, norm
 using Random
 using StableRNGs
 

--- a/test/active_set.jl
+++ b/test/active_set.jl
@@ -318,7 +318,7 @@ end
     # types without the certificate ignore the minimum arguments and scan
     as_cached = FrankWolfe.ActiveSetQuadraticProductCaching(
         [(1 / 25, a) for a in atoms],
-        Matrix{Float64}(I, 6, 6),
+        Matrix{Float64}(LinearAlgebra.I, 6, 6),
         zeros(6),
     )
     @test FrankWolfe.find_atom(as_cached, atoms[7], direction, v_local_loc, Inf) == 7

--- a/test/active_set.jl
+++ b/test/active_set.jl
@@ -320,6 +320,16 @@ end
         @test allunique(res.active_set.atoms)
         @test FrankWolfe.active_set_validate(res.active_set)
     end
+
+    # an atom stored in another representation must be found, never certified
+    # absent: its fresh dot can differ from the stored copy's by an ulp
+    vertices = unique([FrankWolfe.compute_extreme_point(birkhoff, randn(rng, n, n)) for _ in 1:20])
+    dense_set = ActiveSet([(1 / length(vertices), Matrix(v)) for v in vertices])
+    for _ in 1:50
+        dir = randn(rng, n, n)
+        _, _, loc, val, _, _, _, _, _ = FrankWolfe.active_set_argminmax(dense_set, dir)
+        @test FrankWolfe.find_atom(dense_set, vertices[loc], dir, loc, val) == loc
+    end
 end
 
 end # module

--- a/test/active_set.jl
+++ b/test/active_set.jl
@@ -208,7 +208,7 @@ end
     @test active_set.atoms[y_index] == y
     (y2, _, y2_index) =
         FrankWolfe.lp_separation_oracle(lmo, active_set, gradient_dir, 3 + dot(x, gradient_dir), 1)
-    # found new vertex not in active set, and said so without a scan
+    # found new vertex not in active set
     @test y2 ∉ active_set.atoms
     @test y2_index == -1
 
@@ -262,14 +262,14 @@ end
     @test length(FrankWolfe.ActiveSet([(1.0, x0)])) == 1
 end
 
-@testset "find_atom from the minimum a step already holds" begin
+@testset "find_atom with argminmax result" begin
     atoms = [rand(rng, 6) for _ in 1:25]
     active_set = ActiveSet([(1 / 25, a) for a in atoms])
     direction = randn(rng, 6)
     _, v_local, v_local_loc, v_local_value, _, _, _, _, _ =
         FrankWolfe.active_set_argminmax(active_set, direction)
 
-    # every active atom is found at its position, the best one without a scan
+    # every active atom is found at its position, a copy of the best atom included
     for (i, a) in enumerate(atoms)
         @test FrankWolfe.find_atom(active_set, a, direction, v_local_loc, v_local_value) == i
     end
@@ -299,7 +299,7 @@ end
     @test FrankWolfe.find_atom(active_set, atoms[3], direction, -1, -Inf) == 3
     @test FrankWolfe.find_atom(active_set, rand(rng, 6), direction, -1, -Inf) == -1
 
-    # the update path uses it: no atom is ever stored twice, on sparse atoms too
+    # end-to-end on sparse atoms (Birkhoff): the update paths must never store an atom twice
     n = 8
     xp = rand(rng, n, n)
     f(x) = dot(x - xp, x - xp)


### PR DESCRIPTION
Every step that keeps an active set has already computed `dot(a, direction)` for each active atom in `active_set_argminmax` and holds the minimum. If the LMO vertex `v` were in the active set, `dot(v, direction)` would be one of those values, so a strictly smaller value proves `v` is absent without touching an atom. Equality is a tie and falls back to the scan.

`find_atom(active_set, atom, direction, best_index, best_value)` implements this and replaces the scan wherever `active_set_update!` was passed `nothing`: BPCG, pairwise FW (lazy and not), blended CG, and the block-coordinate driver. `lp_separation_oracle` now returns the position alongside the atom. `corrective_frankwolfe.jl` keeps the scan, since no minimum is in scope at its call site. Only `ActiveSet` uses the certificate; the other active-set types fall back until their minimum is known to be the same function.

Birkhoff timings, script in [frankwolfe-active-set-lookup](https://github.com/Tewf/frankwolfe-active-set-lookup):

| run | master | this branch | `find_atom` scans |
|---|---|---|---|
| pairwise FW, n=60, 20k it. | 71.4 s | 66.3 s | 20,001 → 0 |
| pairwise FW, n=25, 8k it. | 2.75 s | 2.42 s | 8,001 → 0 |
| lazy BPCG, n=60, 20k it. | 2.22 s | 2.32 s | 426 → 0 |

Pairwise FW is where it pays: the active set reaches 9,368 atoms and the scan is 7.3 s of that 71.4 s run. Lazy BPCG keeps 426 atoms and has nothing to gain. Same final active set and objective in all three, and the trajectory tests pass unchanged.

Tests in `test/active_set.jl`. Happy to say more about the alternatives measured and refused if useful.

Fixes #244